### PR TITLE
Move from keptn-sandbox to keptn-contrib

### DIFF
--- a/.ci_env
+++ b/.ci_env
@@ -1,4 +1,4 @@
-DOCKER_ORGANIZATION="keptnsandbox"
+DOCKER_ORGANIZATION="keptncontrib"
 IMAGE="job-executor-service"
 IMAGE_INITCONTAINER="job-executor-service-initcontainer"
 DOCKERFILE_INITCONTAINER="initcontainer.Dockerfile"

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ build-lint:
 	GOOS=darwin GOARCH=amd64 go build -o bin/job-lint-darwin-amd64 ./cmd/job-executor-service-lint
 
 build-docker-service:
-	@echo "Building docker image keptnsandbox/job-executor-service:$(TAG)"
-	docker build . -f Dockerfile -t keptnsandbox/job-executor-service:$(TAG)
+	@echo "Building docker image keptncontrib/job-executor-service:$(TAG)"
+	docker build . -f Dockerfile -t keptncontrib/job-executor-service:$(TAG)
 
 build-docker-initcontainer:
-	@echo "Building docker image keptnsandbox/job-executor-service-initcontainer:$(TAG)"
-	docker build . -f initcontainer.Dockerfile -t keptnsandbox/job-executor-service-initcontainer:$(TAG)
+	@echo "Building docker image keptncontrib/job-executor-service-initcontainer:$(TAG)"
+	docker build . -f initcontainer.Dockerfile -t keptncontrib/job-executor-service-initcontainer:$(TAG)
 
 build-docker: build-docker-service build-docker-initcontainer

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Job Executor Service
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/keptn-sandbox/job-executor-service)
-[![Go Report Card](https://goreportcard.com/badge/github.com/keptn-sandbox/job-executor-service)](https://goreportcard.com/report/github.com/keptn-sandbox/job-executor-service)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/keptn-contrib/job-executor-service)
+[![Go Report Card](https://goreportcard.com/badge/github.com/keptn-contrib/job-executor-service)](https://goreportcard.com/report/github.com/keptn-contrib/job-executor-service)
 
 - [Job Executor Service](#job-executor-service)
     - [Why?](#why)
@@ -561,13 +561,13 @@ The credits of this service heavily go to @thschue and @yeahservice who original
 
 ## Compatibility Matrix
 
-| Keptn Version | [Job-Executor-Service Docker Image](https://hub.docker.com/r/keptnsandbox/job-executor-service/tags) | Config version |
+| Keptn Version | [Job-Executor-Service Docker Image](https://hub.docker.com/r/keptncontrib/job-executor-service/tags) | Config version |
 | :-----------: | :--------------------------------------------------------------------------------------------------: | :------------: |
-|     0.8.3     |                               keptnsandbox/job-executor-service:0.1.0                                |       -        |
-|     0.8.3     |                               keptnsandbox/job-executor-service:0.1.1                                |       -        |
-|     0.8.4     |                               keptnsandbox/job-executor-service:0.1.2                                |       v1       |
-|     0.8.6     |                               keptnsandbox/job-executor-service:0.1.3                                |       v2       |
-|     0.9.0     |                               keptnsandbox/job-executor-service:0.1.4                                |       v2       |
+|     0.8.3     |                               keptncontrib/job-executor-service:0.1.0                                |       -        |
+|     0.8.3     |                               keptncontrib/job-executor-service:0.1.1                                |       -        |
+|     0.8.4     |                               keptncontrib/job-executor-service:0.1.2                                |       v1       |
+|     0.8.6     |                               keptncontrib/job-executor-service:0.1.3                                |       v2       |
+|     0.9.0     |                               keptncontrib/job-executor-service:0.1.4                                |       v2       |
 
 ## Installation
 
@@ -596,7 +596,7 @@ Adapt and use the following command in case you want to up- or downgrade your in
 the `$VERSION` placeholder):
 
 ```console
-kubectl -n keptn set image deployment/job-executor-service job-executor-service=keptnsandbox/job-executor-service:$VERSION --record
+kubectl -n keptn set image deployment/job-executor-service job-executor-service=keptncontrib/job-executor-service:$VERSION --record
 ```
 
 ### Uninstall
@@ -626,10 +626,10 @@ the [Golang community](https://github.com/golang/go/wiki/CodeReviewComments).
 
 * Build the binary: `go build -ldflags '-linkmode=external' -v -o job-executor-service`
 * Run tests: `go test -race -v ./...`
-* Build the docker image: `docker build . -t keptnsandbox/job-executor-service:dev` (Note: Ensure that you use the
+* Build the docker image: `docker build . -t keptncontrib/job-executor-service:dev` (Note: Ensure that you use the
   correct DockerHub account/organization)
-* Run the docker image locally: `docker run --rm -it -p 8080:8080 keptnsandbox/job-executor-service:dev`
-* Push the docker image to DockerHub: `docker push keptnsandbox/job-executor-service:dev` (Note: Ensure that you use the
+* Run the docker image locally: `docker run --rm -it -p 8080:8080 keptncontrib/job-executor-service:dev`
+* Push the docker image to DockerHub: `docker push keptncontrib/job-executor-service:dev` (Note: Ensure that you use the
   correct DockerHub account/organization)
 * Deploy the service using `kubectl`: `kubectl apply -f deploy/`
 * Delete/undeploy the service using `kubectl`: `kubectl delete -f deploy/`
@@ -666,7 +666,7 @@ You can find the details in [.github/workflows/tests.yml](.github/workflows/test
 This repo uses GH Actions and Workflows to test the code and automatically build docker images.
 
 Docker Images are automatically pushed based on the configuration done in [.ci_env](.ci_env) and the
-two [GitHub Secrets](https://github.com/keptn-sandbox/job-executor-service/settings/secrets/actions)
+two [GitHub Secrets](https://github.com/keptn-contrib/job-executor-service/settings/secrets/actions)
 
 * `REGISTRY_USER` - your DockerHub username
 * `REGISTRY_PASSWORD` - a DockerHub [access token](https://hub.docker.com/settings/security) (alternatively, your
@@ -693,7 +693,7 @@ If any problems occur, fix them in the release branch and test them again.
 Once you have confirmed that everything works and your version is ready to go, you should
 
 * create a new release on the release branch using
-  the [GitHub releases page](https://github.com/keptn-sandbox/job-executor-service/releases), and
+  the [GitHub releases page](https://github.com/keptn-contrib/job-executor-service/releases), and
 * merge any changes from the release branch back to the master branch.
 
 ## License

--- a/cmd/job-executor-service-initcontainer/main.go
+++ b/cmd/job-executor-service-initcontainer/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"keptn-sandbox/job-executor-service/pkg/file"
-	"keptn-sandbox/job-executor-service/pkg/keptn"
+	"keptn-contrib/job-executor-service/pkg/file"
+	"keptn-contrib/job-executor-service/pkg/keptn"
 	"log"
 	"net/url"
 	"os"

--- a/cmd/job-executor-service-lint/main.go
+++ b/cmd/job-executor-service-lint/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"io/ioutil"
-	"keptn-sandbox/job-executor-service/pkg/config"
+	"keptn-contrib/job-executor-service/pkg/config"
 	"log"
 	"os"
 )

--- a/cmd/job-executor-service/main.go
+++ b/cmd/job-executor-service/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 	"errors"
-	v1 "k8s.io/api/core/v1"
-	"keptn-sandbox/job-executor-service/pkg/eventhandler"
-	"keptn-sandbox/job-executor-service/pkg/k8sutils"
+	"keptn-contrib/job-executor-service/pkg/eventhandler"
+	"keptn-contrib/job-executor-service/pkg/k8sutils"
 	"log"
 	"os"
 	"strings"
+
+	v1 "k8s.io/api/core/v1"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2" // make sure to use v2 cloudevents here
 	"github.com/kelseyhightower/envconfig"

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: job-executor-service
-          image: keptnsandbox/job-executor-service:0.1.4
+          image: keptncontrib/job-executor-service:0.1.4
           ports:
             - containerPort: 8080
           resources:
@@ -37,7 +37,7 @@ spec:
             - name: JOB_NAMESPACE
               value: 'keptn'
             - name: INIT_CONTAINER_IMAGE
-              value: 'keptnsandbox/job-executor-service-initcontainer:0.1.4'
+              value: 'keptncontrib/job-executor-service-initcontainer:0.1.4'
             - name: DEFAULT_RESOURCE_LIMITS_CPU
               value: "1"
             - name: DEFAULT_RESOURCE_LIMITS_MEMORY

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module keptn-sandbox/job-executor-service
+module keptn-contrib/job-executor-service
 
 go 1.16
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -11,7 +11,7 @@ The following table lists the configurable parameters of the job-executor-servic
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `jobexecutorservice.image.repository` | Container image name | `"docker.io/keptnsandbox/job-executor-service"` |
+| `jobexecutorservice.image.repository` | Container image name | `"docker.io/keptncontrib/job-executor-service"` |
 | `jobexecutorservice.image.pullPolicy` | Kubernetes image pull policy | `"IfNotPresent"` |
 | `jobexecutorservice.image.tag` | Container tag | `""` |
 | `jobexecutorservice.service.enabled` | Creates a kubernetes service for the job-executor-service | `true` |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,6 @@
 jobexecutorservice:
   image:
-    repository: docker.io/keptnsandbox/job-executor-service # Container Image Name
+    repository: docker.io/keptncontrib/job-executor-service # Container Image Name
     pullPolicy: Always                       # Kubernetes Image Pull Policy
     tag: ""                                  # Container Tag
   service:
@@ -8,7 +8,7 @@ jobexecutorservice:
 
 jobexecutorserviceinitcontainer:
   image:
-    repository: docker.io/keptnsandbox/job-executor-service-initcontainer # Container Image Name
+    repository: docker.io/keptncontrib/job-executor-service-initcontainer # Container Image Name
     tag: ""                                                               # Container Tag
 
 distributor:

--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -3,6 +3,13 @@ package eventhandler
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"keptn-contrib/job-executor-service/pkg/config"
+	"keptn-contrib/job-executor-service/pkg/k8sutils"
+	k8sutilsfake "keptn-contrib/job-executor-service/pkg/k8sutils/fake"
+	"testing"
+	"time"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding/spec"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -11,12 +18,6 @@ import (
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	keptnfake "github.com/keptn/go-utils/pkg/lib/v0_2_0/fake"
 	"gotest.tools/assert"
-	"io/ioutil"
-	"keptn-sandbox/job-executor-service/pkg/config"
-	"keptn-sandbox/job-executor-service/pkg/k8sutils"
-	k8sutilsfake "keptn-sandbox/job-executor-service/pkg/k8sutils/fake"
-	"testing"
-	"time"
 )
 
 const testEvent = `
@@ -134,8 +135,8 @@ func TestStartK8s(t *testing.T) {
 				MaxPollDuration: &maxPollDuration,
 			},
 			{
-				Name: "Run locust healthy snack tests",
-				Namespace:       jobNamespace2,
+				Name:      "Run locust healthy snack tests",
+				Namespace: jobNamespace2,
 			},
 		},
 	}

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -3,8 +3,8 @@ package eventhandler
 import (
 	"encoding/json"
 	"fmt"
-	"keptn-sandbox/job-executor-service/pkg/config"
-	"keptn-sandbox/job-executor-service/pkg/k8sutils"
+	"keptn-contrib/job-executor-service/pkg/config"
+	"keptn-contrib/job-executor-service/pkg/k8sutils"
 	"log"
 	"math"
 	"strconv"
@@ -35,7 +35,7 @@ type jobLogs struct {
 
 type dataForFinishedEvent struct {
 	start time.Time
-	end time.Time
+	end   time.Time
 }
 
 // HandleEvent handles all events in a generic manner

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -2,11 +2,12 @@ package file
 
 import (
 	"fmt"
-	"github.com/spf13/afero"
-	"keptn-sandbox/job-executor-service/pkg/config"
-	"keptn-sandbox/job-executor-service/pkg/keptn"
+	"keptn-contrib/job-executor-service/pkg/config"
+	"keptn-contrib/job-executor-service/pkg/keptn"
 	"log"
 	"path/filepath"
+
+	"github.com/spf13/afero"
 )
 
 // MountFiles requests all specified files of a task from the keptn configuration service and copies them to /keptn

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -2,12 +2,13 @@ package file
 
 import (
 	"errors"
+	"keptn-contrib/job-executor-service/pkg/keptn"
+	keptnfake "keptn-contrib/job-executor-service/pkg/keptn/fake"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/afero"
 	"gotest.tools/assert"
-	"keptn-sandbox/job-executor-service/pkg/keptn"
-	keptnfake "keptn-sandbox/job-executor-service/pkg/keptn/fake"
-	"testing"
 )
 
 const simpleConfig = `

--- a/pkg/k8sutils/connect.go
+++ b/pkg/k8sutils/connect.go
@@ -1,10 +1,11 @@
 package k8sutils
 
 import (
+	"keptn-contrib/job-executor-service/pkg/config"
+
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	keptnutils "github.com/keptn/kubernetes-utils/pkg"
 	"k8s.io/client-go/kubernetes"
-	"keptn-sandbox/job-executor-service/pkg/config"
 )
 
 // k8sImpl is used to interact with kubernetes jobs

--- a/pkg/k8sutils/fake/connect_mock.go
+++ b/pkg/k8sutils/fake/connect_mock.go
@@ -5,8 +5,8 @@
 package fake
 
 import (
-	config "keptn-sandbox/job-executor-service/pkg/config"
-	k8sutils "keptn-sandbox/job-executor-service/pkg/k8sutils"
+	config "keptn-contrib/job-executor-service/pkg/config"
+	k8sutils "keptn-contrib/job-executor-service/pkg/k8sutils"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
-	"gopkg.in/yaml.v2"
-	"keptn-sandbox/job-executor-service/pkg/config"
+	"keptn-contrib/job-executor-service/pkg/config"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"gopkg.in/yaml.v2"
 
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 
@@ -181,7 +182,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 }
 
 func (k8s *k8sImpl) AwaitK8sJobDone(jobName string, maxPollCount int, pollIntervalInSeconds int, namespace string) error {
-		jobs := k8s.clientset.BatchV1().Jobs(namespace)
+	jobs := k8s.clientset.BatchV1().Jobs(namespace)
 
 	currentPollCount := 0
 

--- a/pkg/k8sutils/job_test.go
+++ b/pkg/k8sutils/job_test.go
@@ -3,7 +3,7 @@ package k8sutils
 import (
 	"context"
 	"encoding/json"
-	"keptn-sandbox/job-executor-service/pkg/config"
+	"keptn-contrib/job-executor-service/pkg/config"
 	"strings"
 	"testing"
 
@@ -379,9 +379,9 @@ func TestSetCustomNamespace(t *testing.T) {
 	err := k8s.CreateK8sJob(jobName, &config.Action{
 		Name: jobName,
 	}, config.Task{
-		Name:       jobName,
-		Image:      "alpine",
-		Cmd:        []string{"ls"},
+		Name:  jobName,
+		Image: "alpine",
+		Cmd:   []string{"ls"},
 	}, &eventData, JobSettings{
 		JobNamespace: namespace,
 		DefaultResourceRequirements: &corev1.ResourceRequirements{
@@ -420,9 +420,9 @@ func TestSetEmptyNamespace(t *testing.T) {
 	err := k8s.CreateK8sJob(jobName, &config.Action{
 		Name: jobName,
 	}, config.Task{
-		Name:       jobName,
-		Image:      "alpine",
-		Cmd:        []string{"ls"},
+		Name:  jobName,
+		Image: "alpine",
+		Cmd:   []string{"ls"},
 	}, &eventData, JobSettings{
 		JobNamespace: namespace,
 		DefaultResourceRequirements: &corev1.ResourceRequirements{

--- a/pkg/keptn/config_service_test.go
+++ b/pkg/keptn/config_service_test.go
@@ -1,13 +1,14 @@
 package keptn
 
 import (
+	keptnfake "keptn-contrib/job-executor-service/pkg/keptn/fake"
+	"net/url"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/spf13/afero"
 	"gotest.tools/assert"
-	keptnfake "keptn-sandbox/job-executor-service/pkg/keptn/fake"
-	"net/url"
-	"testing"
 )
 
 func CreateResourceHandlerMock(t *testing.T) *keptnfake.MockResourceHandler {

--- a/scripts/build-push-deploy-ks3.sh
+++ b/scripts/build-push-deploy-ks3.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-docker build . -f Dockerfile -t keptnsandbox/job-executor-service:latest
-docker push keptnsandbox/job-executor-service:latest
+docker build . -f Dockerfile -t keptncontrib/job-executor-service:latest
+docker push keptncontrib/job-executor-service:latest
 
-docker build . -f initcontainer.Dockerfile -t keptnsandbox/job-executor-service-initcontainer:latest
-docker push keptnsandbox/job-executor-service-initcontainer:latest
+docker build . -f initcontainer.Dockerfile -t keptncontrib/job-executor-service-initcontainer:latest
+docker push keptncontrib/job-executor-service-initcontainer:latest
 
 k3s kubectl -n keptn delete deployment job-executor-service
 k3s kubectl -n keptn apply -f deploy/service.yaml -n keptn

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v1beta13
 kind: Config
 build:
   artifacts:
-    - image: keptnsandbox/job-executor-service
+    - image: keptncontrib/job-executor-service
       docker:
         dockerfile: Dockerfile
         buildArgs:


### PR DESCRIPTION
# This PR

moves all relevant part of this repo from keptn-sandbox to keptn-contrib (including the DockerHub organization used).

# Related issues

#93 