### PR TITLE
feat: Add support for ttlSecondsAfterFinished (#44)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,7 @@ type Task struct {
 	WorkingDir      string     `yaml:"workingDir"`
 	MaxPollDuration *int       `yaml:"maxPollDuration"`
 	Namespace       string     `yaml:"namespace"`
+	TTLSecondsAfterFinished *int32 `yaml:"ttlSecondsAfterFinished"`
 }
 
 // Env value from the event which will be added as env to the job

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -79,6 +79,13 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 		return fmt.Errorf("could not prepare env for job %v: %v", jobName, err.Error())
 	}
 
+	var TTLSecondsAfterFinished *int32
+	if task.TTLSecondsAfterFinished == nil {
+		*TTLSecondsAfterFinished = 600
+	} else {
+		TTLSecondsAfterFinished = task.TTLSecondsAfterFinished
+	}
+
 	jobSpec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -168,7 +175,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 				},
 			},
 			BackoffLimit: &backOffLimit,
-			TTLSecondsAfterFinished: task.TTLSecondsAfterFinished,
+			TTLSecondsAfterFinished: TTLSecondsAfterFinished,
 		},
 	}
 

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -81,7 +81,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 
 	var TTLSecondsAfterFinished *int32
 	if task.TTLSecondsAfterFinished == nil {
-		*TTLSecondsAfterFinished = 600
+		*TTLSecondsAfterFinished = 21600
 	} else {
 		TTLSecondsAfterFinished = task.TTLSecondsAfterFinished
 	}

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -79,11 +79,11 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 		return fmt.Errorf("could not prepare env for job %v: %v", jobName, err.Error())
 	}
 
-	var TTLSecondsAfterFinished *int32
+	var TTLSecondsAfterFinished int32
 	if task.TTLSecondsAfterFinished == nil {
-		*TTLSecondsAfterFinished = 21600
+		TTLSecondsAfterFinished = 21600
 	} else {
-		TTLSecondsAfterFinished = task.TTLSecondsAfterFinished
+		TTLSecondsAfterFinished = *task.TTLSecondsAfterFinished
 	}
 
 	jobSpec := &batchv1.Job{
@@ -175,7 +175,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 				},
 			},
 			BackoffLimit: &backOffLimit,
-			TTLSecondsAfterFinished: TTLSecondsAfterFinished,
+			TTLSecondsAfterFinished: &TTLSecondsAfterFinished,
 		},
 	}
 

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -87,6 +87,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 		Spec: batchv1.JobSpec{
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
+
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsUser:    convert(1000),
 						RunAsGroup:   convert(2000),
@@ -167,6 +168,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 				},
 			},
 			BackoffLimit: &backOffLimit,
+			TTLSecondsAfterFinished: task.TTLSecondsAfterFinished,
 		},
 	}
 


### PR DESCRIPTION
Implements the` TTLSecondsAfterFinished` parameter to cleanup Jobs after they have reached the `Completed` status.

## Usage

```
apiVersion: v2
actions:
  - name: "Print files"
    events:
      - name: "sh.keptn.event.sample.triggered"
    tasks:
      - name: "Show files in bin"
        image: "alpine"
        workingDir: "/bin"
        cmd:
          - ls
        ttlSecondsAfterFinished: 60
``` 

## Fixes
#44 
