### PR TITLE
chore: Use validate-semantic-pr workflow from keptn/gh-automation repo

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -5,47 +5,19 @@ on:
       - opened
       - edited
       - synchronize
-defaults:
-  run:
-    shell: bash
 jobs:
   validate:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Validate Pull Request
-        uses: amannn/action-semantic-pull-request@7bfb19c48fc334d3dacb072cf982e81535041209 # pin@v3.4.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Configure which types are allowed.
-          # Default: https://github.com/commitizen/conventional-commit-types
-          types: |
-            feat
-            fix
-            build
-            chore
-            ci
-            docs
-            perf
-            refactor
-            revert
-            style
-            test
-          # Configure which scopes are allowed.
-          scopes: |
-            api
-            cli
-            core
-            install
-            cloudevents
-            deps
-            deps-dev
-            distributor
-            docs
-          # Configure that a scope must always be provided.
-          requireScope: false
-          # When using "Squash and merge" on a PR with only one commit, GitHub
-          # will suggest using that commit message instead of the PR title for the
-          # merge commit, and it's easy to commit this by mistake. Enable this option
-          # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@main
+    with:
+      # Configure which scopes are allowed.
+      scopes: |
+        api
+        cli
+        core
+        install
+        cloudevents
+        deps
+        deps-dev
+        distributor
+        docs
+        release


### PR DESCRIPTION
## This PR

- Updates the validate-semantic-pr workflow to use the action stoerd in the keptn/gh-automation repo
