### PR TITLE
feat(core): upgrade to keptn 0.10.0 (#106)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o job-exec
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.15
 ENV ENV=production
 
 # Install extra packages

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -5,6 +5,12 @@ kind: Deployment
 metadata:
   name: job-executor-service
   namespace: keptn
+  labels:
+    app.kubernetes.io/name: job-executor-service
+    app.kubernetes.io/instance: keptn
+    app.kubernetes.io/part-of: keptn-keptn
+    app.kubernetes.io/component: execution-plane
+    app.kubernetes.io/version: 0.1.4
 spec:
   selector:
     matchLabels:
@@ -15,6 +21,9 @@ spec:
       labels:
         run: job-executor-service
         app.kubernetes.io/name: job-executor-service
+        app.kubernetes.io/instance: keptn
+        app.kubernetes.io/part-of: keptn-keptn
+        app.kubernetes.io/component: execution-plane
         app.kubernetes.io/version: 0.1.4
     spec:
       containers:
@@ -47,9 +56,9 @@ spec:
             - name: DEFAULT_RESOURCE_REQUESTS_MEMORY
               value: "128Mi"
             - name: ALWAYS_SEND_FINISHED_EVENT
-              value: false
+              value: "false"
         - name: distributor
-          image: keptn/distributor:0.9.0
+          image: keptn/distributor:0.10.0
           livenessProbe:
             httpGet:
               path: /health

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.9.0
+	github.com/keptn/go-utils v0.10.0
 	github.com/keptn/kubernetes-utils v0.9.0
 	github.com/spf13/afero v1.6.0
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.8.5/go.mod h1:FiCd1Dzw6fLhg3hxD0lEfeGXSNVVPUn9EguTWKweyho=
-github.com/keptn/go-utils v0.9.0 h1:UVRB6GEvcjszSCdszYccLzEcAVbBD8Jv+vBl5uy9ZNo=
-github.com/keptn/go-utils v0.9.0/go.mod h1:YOzlxekwyR8WTXiMg9V8mEX+aZIoztAZpMFMwF5iyng=
+github.com/keptn/go-utils v0.10.0 h1:ViYtBqcO6yf8pBkAUKWhCOkWDXdhBjzyP7xu3fFTwtI=
+github.com/keptn/go-utils v0.10.0/go.mod h1:ub4G0WZUckc3TizUoe5jKqfCOOLiH5pnf4M1SDCOT0M=
 github.com/keptn/kubernetes-utils v0.9.0 h1:UlU3qj/80TcFEAHShRlLwvgJtpK/b5/+GpVJCCGcarM=
 github.com/keptn/kubernetes-utils v0.9.0/go.mod h1:aP+xH5Rs0M1kV4Ny/E8gLT9XDXwIUCiAduA2Em76QyA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,7 +18,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.9.0"                             # Container Tag
+    tag: "0.10.0"                             # Container Tag
 
 remoteControlPlane:
   enabled: true                              # Enables remote execution plane mode

--- a/initcontainer.Dockerfile
+++ b/initcontainer.Dockerfile
@@ -36,7 +36,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o job-exec
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.15
 ENV ENV=production
 
 # Install extra packages


### PR DESCRIPTION
## This PR

- upgrades go-utils to 0.10.0
- upgrades keptn/distributor to 0.10.0
- upgrades alpine from 3.11 to 3.15 in both Dockerfiles

Fixes #106 

Proof:
![image](https://user-images.githubusercontent.com/56065213/145038962-314ede4a-6cca-406f-b5ea-2f62bb54a45e.png)
