### PR TITLE
build: fix pre-release workflow versioning

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ jobs:
   pre-release:
     needs: test
     name: Pre-Release
-    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.2.0
+    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.3.0
 
   docker_build:
     needs: [pre-release]

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -7,12 +7,14 @@ on:
       - synchronize
 jobs:
   validate:
-    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@main
+    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@v1.3.0
     with:
       # Configure which scopes are allowed.
       scopes: |
         api
         cli
+        lint
+        initcontainer
         core
         install
         cloudevents

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,51 @@
+{
+  "tagPrefix": "",
+  "preMajor": true,
+  "types": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "chore",
+      "section": "Other"
+    },
+    {
+      "type": "docs",
+      "section": "Docs"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "build",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring"
+    },
+    {
+      "type": "revert",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "hidden": true
+    }
+  ]
+}
+


### PR DESCRIPTION
## This PR

- Fixes the versioning schema used for (pre-)releases by adding a .versionrc file
- Uses the latest released version of keptn/gh-automation workflows
- adds `lint` and `initcontainer` as valid contexts for semantic commit messages
