### PR TITLE
feat(core): support imagePullPolicy for tasks(#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
         - [Resource quotas](#resource-quotas)
         - [Poll duration](#poll-duration)
         - [Job namespace](#job-namespace)
+        - [Job image pull policy](#job-image-pull-policy)
         - [Send start/finished event if the job config.yaml can't be found](#send-startfinished-event-if-the-job-configyaml-cant-be-found)
         - [Additional Event Data](#additional-event-data)
         - [Remote Control Plane](#remote-control-plane)
@@ -490,6 +491,37 @@ tasks:
     ...
     namespace: carts
 ```
+
+### Job Image Pull Policy
+By default the image for the tasks will be pulled according to 
+[kubernetes pull policy defaults](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting).
+
+It's possible to override the pull policy by specifying the desired value in the task:
+
+```yaml
+tasks:
+  - name: "Run locust tests"
+    files:
+      - locust/basic.py
+      - locust/import.py
+      - locust/locust.conf
+    image: "locustio/locust"
+    imagePullPolicy: "Always"
+    cmd:
+      - locust
+    args:
+      - '--config'
+      - /keptn/locust/locust.conf
+      - '-f'
+      - /keptn/locust/basic.py
+      - '--host'
+      - $(HOST)
+```
+
+Allowed values for image pull policy are the same as the [ones accepted by kubernetes](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)
+
+Note: the job executor service does not perform any validation on the image pull policy value. We delegate any validation
+to kubernetes api server.
 
 ### Send start/finished event if the job config.yaml can't be found
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"regexp"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/PaesslerAG/jsonpath"
 )
@@ -38,17 +39,18 @@ type JSONPath struct {
 
 // Task this is the actual task which can be triggered within an Action
 type Task struct {
-	Name            string     `yaml:"name"`
-	Files           []string   `yaml:"files"`
-	Image           string     `yaml:"image"`
-	Cmd             []string   `yaml:"cmd"`
-	Args            []string   `yaml:"args"`
-	Env             []Env      `yaml:"env"`
-	Resources       *Resources `yaml:"resources"`
-	WorkingDir      string     `yaml:"workingDir"`
-	MaxPollDuration *int       `yaml:"maxPollDuration"`
-	Namespace       string     `yaml:"namespace"`
-	TTLSecondsAfterFinished *int32 `yaml:"ttlSecondsAfterFinished"`
+	Name                    string     `yaml:"name"`
+	Files                   []string   `yaml:"files"`
+	Image                   string     `yaml:"image"`
+	ImagePullPolicy         string     `yaml:"imagePullPolicy"`
+	Cmd                     []string   `yaml:"cmd"`
+	Args                    []string   `yaml:"args"`
+	Env                     []Env      `yaml:"env"`
+	Resources               *Resources `yaml:"resources"`
+	WorkingDir              string     `yaml:"workingDir"`
+	MaxPollDuration         *int       `yaml:"maxPollDuration"`
+	Namespace               string     `yaml:"namespace"`
+	TTLSecondsAfterFinished *int32     `yaml:"ttlSecondsAfterFinished"`
 }
 
 // Env value from the event which will be added as env to the job

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"keptn-contrib/job-executor-service/pkg/config"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"keptn-contrib/job-executor-service/pkg/config"
 
 	"github.com/PaesslerAG/jsonpath"
 	"gopkg.in/yaml.v2"
@@ -147,11 +148,12 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 					},
 					Containers: []v1.Container{
 						{
-							Name:       jobName,
-							Image:      task.Image,
-							Command:    task.Cmd,
-							Args:       task.Args,
-							WorkingDir: task.WorkingDir,
+							Name:            jobName,
+							Image:           task.Image,
+							ImagePullPolicy: v1.PullPolicy(task.ImagePullPolicy),
+							Command:         task.Cmd,
+							Args:            task.Args,
+							WorkingDir:      task.WorkingDir,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      jobVolumeName,
@@ -174,7 +176,7 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 				},
 			},
-			BackoffLimit: &backOffLimit,
+			BackoffLimit:            &backOffLimit,
 			TTLSecondsAfterFinished: &TTLSecondsAfterFinished,
 		},
 	}


### PR DESCRIPTION
Introduce support for specifying imagePullPolicy for tasks in
configuration.
No validation of the value is performed on client side,
  we are relying on kubernetes apiserver to perform all the necessary
  validations and apply sensible default as specified in
  https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy