### PR TITLE
build: Fix pre-release workflow (#137, #131)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Docker Build Initcontainer
         id: docker_build_initcontainer
-        uses: ./.github/actions/docker-build
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.3.0
         with:
           TAGS: |
             ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE_INITCONTAINER }}:${{ env.VERSION }}
@@ -98,9 +98,9 @@ jobs:
 
       - name: Rename binaries
         run: |
-          mv ./bin/job-lint-linux-amd64 job-lint-linux-amd64-$VERSION
-          mv ./bin/job-lint-windows-amd64 job-lint-windows-amd64-$VERSION.exe
-          mv ./bin/job-lint-darwin-amd64 job-lint-darwin-amd64-$VERSION
+          mv ./bin/job-lint-linux-amd64 ./bin/job-lint-linux-amd64-$VERSION
+          mv ./bin/job-lint-windows-amd64 ./bin/job-lint-windows-amd64-$VERSION.exe
+          mv ./bin/job-lint-darwin-amd64 ./bin/job-lint-darwin-amd64-$VERSION
 
       - name: Upload release assets
         env:


### PR DESCRIPTION
## This PR

- Fixes docker build in pre-release workflow (was referring to the wrong action; now refers to the action in keptn/gh-automation repo)
- Fixes gh upload lint tool in pre-release workflow (files were moved into the wrong folder, hence the upload failed)

Fixes #137 and #131 

## Proof
![image](https://user-images.githubusercontent.com/56065213/147635897-5822b48a-9a30-408a-860f-8b7c24edd523.png)

![image](https://user-images.githubusercontent.com/56065213/147635905-f77a076d-11b5-4b31-ab78-a99f3931a8ff.png)
