### PR TITLE
chore: Enable skaffold to build and deploy initcontainer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,10 @@ README.md
 .idea
 skaffold.yaml
 reviewdog.yml
-charts/
+chart/
 deploy/
 .github/
 installer/
+bin/
+test-data/
+test-events/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.16.2-alpine as builder
+
 RUN apk add --no-cache gcc libc-dev git
 
 ARG version=develop

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "job-executor-service.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }} # forces pod restart (e.g., when updating helm values)
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "job-executor-service.labels" . | nindent 8 }}
     spec:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -56,9 +56,7 @@
       "properties": {
         "image": {
           "properties": {
-            "repository": {
-              "pattern": "^[a-z0-9-./]{2,127}$"
-            }
+            "repository": {}
           }
         }
       }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,15 +4,20 @@ build:
   local:
     useBuildkit: true
   artifacts:
+    # job executor service
     - image: keptncontrib/job-executor-service
       docker:
         dockerfile: Dockerfile
+    # init container for actual jobs (will be used for every job that is started)
+    - image: keptncontrib/job-executor-service-initcontainer
+      docker:
+        dockerfile: initcontainer.Dockerfile
 # Before executing this, install job-executor-service manually:
 # helm install -n keptn job-executor-service https://github.com/keptn-contrib/job-executor-service/releases/download/0.1.4/job-executor-service-0.1.4.tgz
 deploy:
   helm:
     flags:
-      upgrade: ["--reuse-values"]
+      upgrade: ["--reuse-values"] # keep configuration (e.g., Keptn API Token)
     releases:
       - name: job-executor-service # needs to be the same name as currently used (check via helm ls -n keptn)
         namespace: keptn # needs to be the same namespace as where the helm-chart is currently deployed
@@ -20,6 +25,8 @@ deploy:
         # recreatePods: false # don't recreate all pods
         artifactOverrides:
           image: keptncontrib/job-executor-service
+          jobexecutorserviceinitcontainer:
+            image: keptncontrib/job-executor-service-initcontainer
         imageStrategy:
           helm: { }
         overrides:
@@ -28,5 +35,5 @@ deploy:
               tag: 0.10.0
           resources:
             limits:
-              memory: 512Mi
+              memory: 512Mi # increase memory limit such that debugging using delve works
         chartPath: chart


### PR DESCRIPTION
## This PR

- enables skaffold to also build and deploy the initcontainer
- added a `rollme` annotation to the deployment of job-executor-service such that it always restarts, even when just helm values are updated (and not the Kubernetes image itself)
- Update `Dockerfile` and `initcontainer.Dockerfile` to look the same



## Proof

```
skaffold run --tail
```


![image](https://user-images.githubusercontent.com/56065213/147643513-824542f2-0356-43af-925e-478167f3ad5b.png)

```
keptn trigger delivery ...
```


![image](https://user-images.githubusercontent.com/56065213/147642963-5ee26e74-fb6b-49f2-8954-0493e5df59ad.png)


![image](https://user-images.githubusercontent.com/56065213/147642905-862f2e12-c64c-46e8-854c-fe13a7b6f070.png)

