### PR TITLE
feat(core): Add kubernetes api access to jobs

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -10,3 +10,4 @@ data:
   default_resource_requests_cpu: "50m"
   default_resource_requests_memory: "128Mi"
   always_send_finished_event: "false"
+  enable_kubernetes_api_access: "{{ .Values.jobConfig.enableKubernetesApiAccess | default false }}"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -87,6 +87,11 @@ spec:
               configMapKeyRef:
                 name: job-service-config
                 key: always_send_finished_event
+          - name: ENABLE_KUBERNETES_API_ACCESS
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: enable_kubernetes_api_access
           livenessProbe:
             httpGet:
               path: /health

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,6 +29,9 @@ remoteControlPlane:
     apiValidateTls: true                     # Defines if the control plane certificate should be validated
     token: ""                                # Keptn API Token
 
+jobConfig:
+  enableKubernetesApiAccess: false           # whether or not the started jobs should have Kubernetes API Access
+
 
 imagePullSecrets: [ ]                        # Secrets to use for container registry credentials
 

--- a/cmd/job-executor-service/main.go
+++ b/cmd/job-executor-service/main.go
@@ -47,6 +47,8 @@ type envConfig struct {
 	DefaultResourceRequestsMemory string `envconfig:"DEFAULT_RESOURCE_REQUESTS_MEMORY"`
 	// Respond with .finished event if no configuration found
 	AlwaysSendFinishedEvent string `envconfig:"ALWAYS_SEND_FINISHED_EVENT"`
+	// Whether jobs can access Kubernetes API
+	EnableKubernetesAPIAccess string `envconfig:"ENABLE_KUBERNETES_API_ACCESS"`
 }
 
 // ServiceName specifies the current services name (e.g., used as source when sending CloudEvents)
@@ -105,11 +107,16 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 			InitContainerImage:          env.InitContainerImage,
 			DefaultResourceRequirements: DefaultResourceRequirements,
 			AlwaysSendFinishedEvent:     false,
+			EnableKubernetesAPIAccess:   false,
 		},
 	}
 
 	if env.AlwaysSendFinishedEvent == "true" {
 		eventHandler.JobSettings.AlwaysSendFinishedEvent = true
+	}
+
+	if env.EnableKubernetesAPIAccess == "true" {
+		eventHandler.JobSettings.EnableKubernetesAPIAccess = true
 	}
 
 	// prevent duplicate events - https://github.com/keptn/keptn/issues/3888

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -33,6 +33,7 @@ type JobSettings struct {
 	InitContainerImage                           string
 	DefaultResourceRequirements                  *v1.ResourceRequirements
 	AlwaysSendFinishedEvent                      bool
+	EnableKubernetesAPIAccess                    bool
 }
 
 // CreateK8sJob creates a k8s job with the job-executor-service-initcontainer and the job image of the task
@@ -67,7 +68,15 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 		Medium:    v1.StorageMediumDefault,
 		SizeLimit: &quantity,
 	}
-	automountServiceAccountToken := false
+	automountServiceAccountToken := jobSettings.EnableKubernetesAPIAccess
+
+	// specify empty service account name for job
+	serviceAccountName := ""
+
+	if jobSettings.EnableKubernetesAPIAccess {
+		automountServiceAccountToken = true
+		serviceAccountName = "job-executor-service"
+	}
 
 	runAsNonRoot := true
 	convert := func(s int64) *int64 {
@@ -172,9 +181,10 @@ func (k8s *k8sImpl) CreateK8sJob(jobName string, action *config.Action, task con
 						},
 					},
 					AutomountServiceAccountToken: &automountServiceAccountToken,
+					ServiceAccountName:           serviceAccountName,
 				},
 			},
-			BackoffLimit: &backOffLimit,
+			BackoffLimit:            &backOffLimit,
 			TTLSecondsAfterFinished: &TTLSecondsAfterFinished,
 		},
 	}


### PR DESCRIPTION
## This PR

- Adds Kubernetes API access to jobs via an environment/helm value

## How To Test

Download helm charts from [CI Build](https://github.com/keptn-contrib/job-executor-service/actions/runs/1637358883) and extract them

Install:
```bash
helm upgrade --install -n keptn job-executor-service job-executor-service-0.1.5-dev-PR-146.tgz --set jobConfig.enableKubernetesApiAccess=true --wait
```

Run a job config that requires Kubernetes API access, e.g.:

![image](https://user-images.githubusercontent.com/56065213/147749989-67f5e485-7b86-4d86-990e-cdd6489d9c3c.png)

