### PR TITLE
chore: restructure docs, add new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,86 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/keptn-contrib/job-executor-service)
 [![Go Report Card](https://goreportcard.com/badge/github.com/keptn-contrib/job-executor-service)](https://goreportcard.com/report/github.com/keptn-contrib/job-executor-service)
 
-- [Job Executor Service](#job-executor-service)
+This Keptn integration introduces a new approach of running customizable tasks with Keptn as Kubernetes Jobs.
+
+## Compatibility Matrix
+
+| Keptn Version | [Job-Executor-Service Docker Image](https://hub.docker.com/r/keptncontrib/job-executor-service/tags) | Config version |
+|:-------------:|:----------------------------------------------------------------------------------------------------:|:--------------:|
+|     0.8.3     |                               keptncontrib/job-executor-service:0.1.0                                |       -        |
+|     0.8.3     |                               keptncontrib/job-executor-service:0.1.1                                |       -        |
+|     0.8.4     |                               keptncontrib/job-executor-service:0.1.2                                |       v1       |
+|     0.8.6     |                               keptncontrib/job-executor-service:0.1.3                                |       v2       |
+|     0.9.0     |                               keptncontrib/job-executor-service:0.1.4                                |       v2       |
+|    0.10.0     |                               keptncontrib/job-executor-service:0.1.5                                |       v2       |
+
+## Installation
+
+The *job-executor-service* can be installed as a part of [Keptn's uniform](https://keptn.sh) using `helm`:
+
+```bash
+helm install -n keptn job-executor-service https://github.com/keptn-contrib/job-executor-service/releases/download/<VERSION>/job-executor-service-<VERSION>.tgz
+```
+
+Please replace `<VERSION>` with the actual version you want to install from the compatibility matrix above or the 
+[GitHub releases page](https://github.com/keptn-contrib/job-executor-service/releases).
+
+
+**Note**: Versions 0.1.4 and older need to be installed using `kubectl`, e.g.:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/job-executor-service/release-<VERSION>/deploy/service.yaml
+```
+
+
+## Uninstall
+
+To uninstall *job-executor-service*, run
+
+```bash
+helm uninstall -n keptn job-executor-service
+```
+
+## Development
+
+Development can be conducted using any GoLang compatible IDE/editor (e.g., Jetbrains GoLand, VSCode with Go plugins).
+
+When writing code, it is recommended to follow the coding style suggested by the [Golang community](https://github.com/golang/go/wiki/CodeReviewComments).
+
+### Common tasks
+
+* Build the binary: `go build -ldflags '-linkmode=external' -v -o job-executor-service`
+* Run tests: `go test -race -v ./...`
+* Watch the deployment using `kubectl`: `kubectl -n keptn get deployment job-executor-service -o wide`
+* Get logs using `kubectl`: `kubectl -n keptn logs deployment/job-executor-service -f`
+* Watch the deployed pods using `kubectl`: `kubectl -n keptn get pods -l run=job-executor-service`
+* Deploy the service
+  using [Skaffold](https://skaffold.dev/): `skaffold run --default-repo=<your-docker-registry> --tail` (Note:
+  Replace `<your-docker-registry>` with your DockerHub username
+
+
+### How to release a new version of this service
+
+It is assumed that the current development takes place in the `main` branch (either via Pull Requests or directly).
+
+Creating a release is as simple as using the 
+[Create pre-release](https://github.com/keptn-contrib/job-executor-service/actions/workflows/pre-release.yml) and 
+[Create release](https://github.com/keptn-contrib/job-executor-service/actions/workflows/release.yml) workflows.
+
+**Note**: Creating a pre-release will actually create a GitHub pre-release and tag the latest commit on the specified branch.
+When creating a release, only a draft release as well as a pull request are created. You still need to publish the draft
+release and merge the Pull Request.
+
+## Credits
+
+The credits of this service heavily go to @thschue and @yeahservice who originally came up with this idea. :rocket:
+
+## License
+
+Please find more information in the [LICENSE](LICENSE) file.
+
+## Documentation
+
+- [Documentation](#documentation)
     - [Why?](#why)
     - [How?](#how)
         - [Specifying the working directory](#specifying-the-working-directory)
@@ -25,41 +104,23 @@
         - [Job clean-up](#job-clean-up)
     - [How to validate a job configuration](#how-to-validate-a-job-configuration)
     - [Endless Possibilities](#endless-possibilities)
-    - [Credits](#credits)
-    - [Compatibility Matrix](#compatibility-matrix)
-    - [Installation](#installation)
-        - [Deploy in your Kubernetes cluster](#deploy-in-your-kubernetes-cluster)
-        - [Up- or Downgrading](#up--or-downgrading)
-        - [Uninstall](#uninstall)
-    - [Development](#development)
-        - [Common tasks](#common-tasks)
-        - [Testing Cloud Events](#testing-cloud-events)
-    - [Automation](#automation)
-        - [GitHub Actions: Automated Pull Request Review](#github-actions-automated-pull-request-review)
-        - [GitHub Actions: Unit Tests](#github-actions-unit-tests)
-        - [GH Actions/Workflow: Build Docker Images](#gh-actionsworkflow-build-docker-images)
-    - [How to release a new version of this service](#how-to-release-a-new-version-of-this-service)
-    - [License](#license)
-
-This Keptn service introduces a radical new approach to running tasks with keptn. It provides the means to run any
-container as a Kubernetes Job orchestrated by keptn.
 
 ## Why?
 
-The job-executor-service aims to tackle several current pain points with the current approach of services running in the
-keptn ecosystem:
+The job-executor-service aims to tackle several current pain points with the current approach of services/integrations
+running in the Keptn ecosystem:
 
 | Problem                                                                                                                                                                                                                                                                                                                                        | Solution                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Keptn services are constantly running while listening for cloud events coming in over NATS. This consumes unnecessary resources on the Kubernetes cluster.                                                                                                                                                                                     | By running the defined keptn tasks as short-lived workloads (Kubernetes Jobs), they just consume resources while the task is executed.                                                                                                                                                                                                                                                                                                              |
-| Whenever some new functionality should be triggered by keptn, a new keptn service needs to be written. It usually wraps the functionality of the wanted framework and executes it under the hood. The downside: The code of the new keptn service needs to be written and maintained. This effort scales linearly with the amount of services. | This service can execute any framework with just a few lines of yaml configuration. No need to write or maintain any new code.                                                                                                                                                                                                                                                                                                                      |
-| Keptn services usually filter for a static list of events the trigger the included functionality. This is not configurable. Whenever the service should listen to a new event, the code of the service needs to be changed.                                                                                                                    | The Job Executor Service provides the means to trigger a task execution for any keptn event. This is done by matching a jsonpath to the received event payload.                                                                                                                                                                                                                                                                                     |
-| Keptn services are usually opinionized on how your framework execution looks like. E.g. the locust service just executes three different (statically named) files depending on the test strategy in the shipyard. It is not possible to write tests consisting of multiply files.                                                              | This service provides the possibility to write any specified file from the keptn git repository into a mounted folder (`/keptn`) of the Kubernetes job. This is done by a initcontainer running before the specified image.                                                                                                                                                                                                                         |
-| Support for new functionality in keptn needs to be added to each keptn service individually. E.g. the new secret functionality needs to be included into all of the services running in the keptn execution plane. This slows down the availability of this new feature.                                                                       | The Job Executor Service is a single service which provides the means to run any workload orchestrated by keptn. So, it is possible to support new functionality of keptn just once in this service - and all workloads profit from it. E.g. in the case of the secret functionality, one just needs to support it in this service and suddenly all the triggered Kubernetes Jobs have the correct secrets attached to it as environment variables. |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Keptn services are constantly running on Kubernetes while listening for Cloud Events coming in over NATS, even when idle. This consumes unnecessary resources on the Kubernetes cluster.                                                                                                                                                       | By running the defined Keptn tasks as short-lived workloads (Kubernetes Jobs), they just consume resources while the task is executed.                                                                                                                                                                                                                                                                                                              |
+| Whenever some new functionality should be triggered by Keptn, a new Keptn service needs to be written. It usually wraps the functionality of the wanted framework and executes it under the hood. The downside: The code of the new Keptn service needs to be written and maintained. This effort scales linearly with the amount of services. | This service can execute any framework with just a few lines of yaml configuration. No need to write or maintain any new code.                                                                                                                                                                                                                                                                                                                      |
+| Keptn services usually filter for a static list of events the trigger the included functionality. This is not configurable. Whenever the service should listen to a new event, the code of the service needs to be changed.                                                                                                                    | The Job Executor Service provides the means to trigger a task execution for any Keptn event. This is done by matching a jsonpath to the received event payload.                                                                                                                                                                                                                                                                                     |
+| Keptn services are usually opinionized on how your framework execution looks like. E.g. the locust service just executes three different (statically named) files depending on the test strategy in the shipyard. It is not possible to write tests consisting of multiply files.                                                              | This service provides the possibility to write any specified file from the Keptn git repository into a mounted folder (`/keptn`) of the Kubernetes job. This is done by a initcontainer running before the specified image.                                                                                                                                                                                                                         |
+| Support for new functionality in Keptn needs to be added to each Keptn service individually. E.g. the new secret functionality needs to be included into all of the services running in the Keptn execution plane. This slows down the availability of this new feature.                                                                       | The Job Executor Service is a single service which provides the means to run any workload orchestrated by Keptn. So, it is possible to support new functionality of Keptn just once in this service - and all workloads profit from it. E.g. in the case of the secret functionality, one just needs to support it in this service and suddenly all the triggered Kubernetes Jobs have the correct secrets attached to it as environment variables. |
 
 ## How?
 
-Just put a file into the keptn git repository (in folder `<service>/job/config.yaml`) to specify
+Just put a file into the Keptn config git repository (in folder `<service>/job/config.yaml`) to specify
 
 * the containers which should be run as Kubernetes Jobs and
 * the events for which they should be triggered.
@@ -99,7 +160,7 @@ actions:
             valueFrom: event
 ```
 
-The easiest way to add the `config.yaml` to the keptn git repository is to use the keptn cli:
+The easiest way to add the `config.yaml` to the keptn git repository is to use the `keptn` cli:
 
 ```shell
 keptn add-resource --project=myproject --service=myservice --stage=mystage --resource=config.yaml --resourceUri=job/config.yaml
@@ -620,147 +681,3 @@ For each release beginning with `0.1.3` compatible binaries are attached.
 * Run kaniko inside the cluster and build and push your images. Suddenly, keptn turns into your CI
 * ...
 
-## Credits
-
-The credits of this service heavily go to @thschue and @yeahservice who originally came up with this idea. :rocket:
-
-## Compatibility Matrix
-
-| Keptn Version | [Job-Executor-Service Docker Image](https://hub.docker.com/r/keptncontrib/job-executor-service/tags) | Config version |
-| :-----------: | :--------------------------------------------------------------------------------------------------: | :------------: |
-|     0.8.3     |                               keptncontrib/job-executor-service:0.1.0                                |       -        |
-|     0.8.3     |                               keptncontrib/job-executor-service:0.1.1                                |       -        |
-|     0.8.4     |                               keptncontrib/job-executor-service:0.1.2                                |       v1       |
-|     0.8.6     |                               keptncontrib/job-executor-service:0.1.3                                |       v2       |
-|     0.9.0     |                               keptncontrib/job-executor-service:0.1.4                                |       v2       |
-
-## Installation
-
-The *job-executor-service* can be installed as a part of [Keptn's uniform](https://keptn.sh).
-
-### Deploy in your Kubernetes cluster
-
-To deploy the current version of the *job-executor-service* in your Keptn Kubernetes cluster, apply
-the [`deploy/service.yaml`](deploy/service.yaml) file:
-
-```console
-kubectl apply -f deploy/service.yaml
-```
-
-This should install the `job-executor-service` together with a Keptn `distributor` into the `keptn` namespace, which you
-can verify using
-
-```console
-kubectl -n keptn get deployment job-executor-service -o wide
-kubectl -n keptn get pods -l run=job-executor-service
-```
-
-### Up- or Downgrading
-
-Adapt and use the following command in case you want to up- or downgrade your installed version (specified by
-the `$VERSION` placeholder):
-
-```console
-kubectl -n keptn set image deployment/job-executor-service job-executor-service=keptncontrib/job-executor-service:$VERSION --record
-```
-
-### Uninstall
-
-To delete a deployed *job-executor-service*, use the file `deploy/*.yaml` files from this repository and delete the
-Kubernetes resources:
-
-```console
-kubectl delete -f deploy/service.yaml
-```
-
-## Development
-
-Development can be conducted using any GoLang compatible IDE/editor (e.g., Jetbrains GoLand, VSCode with Go plugins).
-
-It is recommended to make use of branches as follows:
-
-* `master` contains the latest potentially unstable version
-* `release-*` contains a stable version of the service (e.g., `release-0.1.0` contains version 0.1.0)
-* create a new branch for any changes that you are working on, e.g., `feature/my-cool-stuff` or `bug/overflow`
-* once ready, create a pull request from that branch back to the `master` branch
-
-When writing code, it is recommended to follow the coding style suggested by
-the [Golang community](https://github.com/golang/go/wiki/CodeReviewComments).
-
-### Common tasks
-
-* Build the binary: `go build -ldflags '-linkmode=external' -v -o job-executor-service`
-* Run tests: `go test -race -v ./...`
-* Build the docker image: `docker build . -t keptncontrib/job-executor-service:dev` (Note: Ensure that you use the
-  correct DockerHub account/organization)
-* Run the docker image locally: `docker run --rm -it -p 8080:8080 keptncontrib/job-executor-service:dev`
-* Push the docker image to DockerHub: `docker push keptncontrib/job-executor-service:dev` (Note: Ensure that you use the
-  correct DockerHub account/organization)
-* Deploy the service using `kubectl`: `kubectl apply -f deploy/`
-* Delete/undeploy the service using `kubectl`: `kubectl delete -f deploy/`
-* Watch the deployment using `kubectl`: `kubectl -n keptn get deployment job-executor-service -o wide`
-* Get logs using `kubectl`: `kubectl -n keptn logs deployment/job-executor-service -f`
-* Watch the deployed pods using `kubectl`: `kubectl -n keptn get pods -l run=job-executor-service`
-* Deploy the service
-  using [Skaffold](https://skaffold.dev/): `skaffold run --default-repo=your-docker-registry --tail` (Note:
-  Replace `your-docker-registry` with your DockerHub username; also make sure to adapt the image name
-  in [skaffold.yaml](skaffold.yaml))
-
-### Testing Cloud Events
-
-We have dummy cloud-events in the form of [RFC 2616](https://ietf.org/rfc/rfc2616.txt) requests in
-the [test-events/](test-events/) directory. These can be easily executed using third party plugins such as
-the [Huachao Mao REST Client in VS Code](https://marketplace.visualstudio.com/items?itemName=humao.rest-client).
-
-## Automation
-
-### GitHub Actions: Automated Pull Request Review
-
-This repo uses [reviewdog](https://github.com/reviewdog/reviewdog) for automated reviews of Pull Requests.
-
-You can find the details in [.github/workflows/reviewdog.yml](.github/workflows/reviewdog.yml).
-
-### GitHub Actions: Unit Tests
-
-This repo has automated unit tests for pull requests.
-
-You can find the details in [.github/workflows/tests.yml](.github/workflows/tests.yml).
-
-### GH Actions/Workflow: Build Docker Images
-
-This repo uses GH Actions and Workflows to test the code and automatically build docker images.
-
-Docker Images are automatically pushed based on the configuration done in [.ci_env](.ci_env) and the
-two [GitHub Secrets](https://github.com/keptn-contrib/job-executor-service/settings/secrets/actions)
-
-* `REGISTRY_USER` - your DockerHub username
-* `REGISTRY_PASSWORD` - a DockerHub [access token](https://hub.docker.com/settings/security) (alternatively, your
-  DockerHub password)
-
-## How to release a new version of this service
-
-It is assumed that the current development takes place in the master branch (either via Pull Requests or directly).
-
-To make use of the built-in automation using GH Actions for releasing a new version of this service, you should
-
-* branch away from master to a branch called `release-x.y.z` (where `x.y.z` is your version),
-* write release notes in the [releasenotes/](releasenotes/) folder,
-* update the compatibility matrix,
-* check the output of GH Actions builds for the release branch,
-* verify that your image was built and pushed to DockerHub with the right tags,
-* update the image tags for `job-executor-service`, `job-executor-service-initcontainer` and `distributor`
-  in [`deploy/service.yaml`](deploy/service.yaml), [`helm/Chart.yaml`](helm/Chart.yaml) and
-  the `app.kubernetes.io/version` in [`deploy/service.yaml`](deploy/service.yaml)
-* test your service against a working Keptn installation.
-
-If any problems occur, fix them in the release branch and test them again.
-
-Once you have confirmed that everything works and your version is ready to go, you should
-
-* create a new release on the release branch using
-  the [GitHub releases page](https://github.com/keptn-contrib/job-executor-service/releases), and
-* merge any changes from the release branch back to the master branch.
-
-## License
-
-Please find more information in the [LICENSE](LICENSE) file.


### PR DESCRIPTION
## This PR

- Restructures README - move compatibility matrix and installation instructions to the top
- Adds the 0.1.5 release to compatbility matrix (it's pending, coming soon)
- Adds new installation instructions using `helm`