### PR TITLE
Revert "fix(#159) Fix API Token Regex"

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -41,7 +41,7 @@
                 "type": "boolean"
               },
               "token": {
-                "pattern": "^[A-Za-z0-9-.+]{2,63}$"
+                "pattern": "^[A-Za-z0-9-.]{2,63}$"
               }
             }
           }


### PR DESCRIPTION
Still not clear how a '+' character got into the keptn api token . Needs more investigation about the root cause rather than a quick fix. Reverting the change for now till we know more.

Reverts keptn-contrib/job-executor-service#160