### PR TITLE
fix: Revert "Allow '+' in API Token helm value (#160) (#159)"

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -41,7 +41,7 @@
                 "type": "boolean"
               },
               "token": {
-                "pattern": "^[A-Za-z0-9-.+]{2,63}$"
+                "pattern": "^[A-Za-z0-9-.]{2,63}$"
               }
             }
           }


### PR DESCRIPTION
This reverts commit ed463da98fb50b90fa485483f81505bea49855dd.

Still not clear how a '+' character got into the keptn api token.
Needs more investigation about the root cause rather than a quick fix.
Reverting the change till we know more.
Reverts #160

Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>