### PR TITLE
feat: Increase empty-dir size to 128 Mi

### DIFF
--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -52,7 +52,7 @@ func (k8s *k8sImpl) CreateK8sJob(
 	jobVolumeMountPath := "/keptn"
 
 	// TODO configure from outside:
-	quantity := resource.MustParse("20Mi")
+	quantity := resource.MustParse("128Mi")
 
 	jobResourceRequirements := jobSettings.DefaultResourceRequirements
 	if task.Resources != nil {


### PR DESCRIPTION
**Evaluation in progress**

This PR increases the emptyDir size to 128 Mi, in order to be able to use bigger files in a job-executor job.

