### PR TITLE
docs: added more examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ test-data/
 test-events/
 assets/
 gh-actions-scripts/
+examples/

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The easiest way to add the `config.yaml` to the keptn git repository is to use t
 keptn add-resource --project=myproject --service=myservice --stage=mystage --resource=config.yaml --resourceUri=job/config.yaml
 ```
 
+For more extensive examples, please have a look at the [examples folder](examples/).
 
 ## How to validate a job configuration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,85 @@
+# Examples
+
+*Note*: Unless specified otherwise, all commands should be executed from within this folder. It is assumed that job-executor-service is arleady installed and running (in remote execution plane).
+
+## Hello World
+
+**Setup**
+```bash
+keptn create project jes-hello-world --shipyard hello-world/shipyard.yaml
+keptn create service foobar --project jes-hello-world
+keptn add-resource --project jes-hello-world --service foobar --all-stages --resource hello-world/job-config.yaml --resourceUri job/config.yaml
+keptn add-resource --project jes-hello-world --service foobar --all-stages --resource hello-world/greetings.txt --resourceUri greetings.txt
+```
+
+**Execution**
+```bash
+keptn trigger delivery --project jes-hello-world --service foobar --image foobar:1.2.3
+```
+
+**Expected Output**
+You should see that the sequence has finished in Bridge with the following Cloud Event and output:
+
+```
+Job job-executor-service-job-a2585307-57be-40af-9c4f-eb33-1 finished successfully!
+
+Logs:
+Hello jes-hello-world:foobar:dev
+
+
+Job job-executor-service-job-a2585307-57be-40af-9c4f-eb33-2 finished successfully!
+
+Logs:
+Spanish: hola.
+French: bonjour.
+German: guten tag.
+Italian: salve.
+Chinese: nǐn hǎo.
+Portuguese: olá
+Arabic: asalaam alaikum.
+Japanese: konnichiwa.
+```
+
+## Locust
+
+**Note**: Make sure jmeter-service is not running (e.g., uninstall using `helm -n keptn uninstall jmeter-service`)
+
+**Setup**
+```bash
+keptn create project jes-locust --shipyard locust/shipyard.yaml
+keptn create service helloservice --project jes-locust
+keptn add-resource --project jes-locust --service helloservice --stage=qa --resource locust/job-config.yaml --resourceUri job/config.yaml
+keptn add-resource --project jes-locust --service helloservice --stage=qa --resource locust/basic.py
+keptn add-resource --project jes-locust --service helloservice --stage=qa --resource locust/locust.conf
+```
+
+**Execution**
+```bash
+keptn send event -f locust/cloud-event.json
+```
+
+
+
+## Kubectl Example
+
+**Setup**
+```bash
+keptn create project jes-kubectl --shipyard kubectl/shipyard.yaml
+keptn create service foobar --project jes-kubectl
+keptn add-resource --project jes-kubectl --service foobar --all-stages --resource kubectl/job-config.yaml --resourceUri job/config.yaml
+```
+
+**Execution**
+```bash
+keptn trigger delivery --project jes-kubectl --service foobar --image foobar:1.2.3
+```
+
+**Expected Output**
+In the default setup of job-executor-service this will fail, because jobs/workloads cannot access the Kubernetes API:
+```
+Job job-executor-service-job-700e65cb-0f85-46fb-94e2-266b-1 failed: job job-executor-service-job-700e65cb-0f85-46fb-94e2-266b-1 failed. Reason: BackoffLimitExceeded, Message: Job has reached the specified backoff limit
+
+Logs: 
+The connection to the server localhost:8080 was refused - did you specify the right host or port?
+```
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-*Note*: Unless specified otherwise, all commands should be executed from within this folder. It is assumed that job-executor-service is arleady installed and running (in remote execution plane).
+*Note*: Unless specified otherwise, all commands should be executed from within this folder. It is assumed that job-executor-service is already installed and running (in remote execution plane).
 
 ## Hello World
 

--- a/examples/hello-world/greetings.txt
+++ b/examples/hello-world/greetings.txt
@@ -1,0 +1,8 @@
+Spanish: hola.
+French: bonjour.
+German: guten tag.
+Italian: salve.
+Chinese: nǐn hǎo.
+Portuguese: olá
+Arabic: asalaam alaikum.
+Japanese: konnichiwa.

--- a/examples/hello-world/job-config.yaml
+++ b/examples/hello-world/job-config.yaml
@@ -1,0 +1,22 @@
+
+apiVersion: v2
+actions:
+  - name: "My remote task"
+    events:
+      - name: "sh.keptn.event.my-task.triggered"
+    tasks:
+      - name: "Say hi to project:service:stage"
+        image: "alpine"
+        cmd:
+          - echo
+        args:
+          - "Hello $(KEPTN_PROJECT):$(KEPTN_SERVICE):$(KEPTN_STAGE)"
+
+      - name: "Say hi to in different languages"
+        image: "alpine"
+        files:
+          - "greetings.txt"
+        cmd:
+          - cat
+        args:
+          - "/keptn/greetings.txt"

--- a/examples/hello-world/shipyard.yaml
+++ b/examples/hello-world/shipyard.yaml
@@ -1,0 +1,11 @@
+apiVersion: spec.keptn.sh/0.2.2
+kind: "Shipyard"
+metadata:
+  name: "shipyard-job-exec-hello-world"
+spec:
+  stages:
+    - name: "dev"
+      sequences:
+        - name: "delivery"
+          tasks:
+            - name: "my-task"

--- a/examples/kubectl/job-config.yaml
+++ b/examples/kubectl/job-config.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: v2
+actions:
+  - name: "My remote task"
+    events:
+      - name: "sh.keptn.event.my-task.triggered"
+    tasks:
+      - name: "Run kubectl"
+        image: "bitnami/kubectl"
+        cmd:
+          - kubectl
+        args:
+          - "get"
+          - "secrets"

--- a/examples/kubectl/shipyard.yaml
+++ b/examples/kubectl/shipyard.yaml
@@ -1,0 +1,11 @@
+apiVersion: spec.keptn.sh/0.2.2
+kind: "Shipyard"
+metadata:
+  name: "shipyard-job-exec-hello-world"
+spec:
+  stages:
+    - name: "dev"
+      sequences:
+        - name: "delivery"
+          tasks:
+            - name: "my-task"

--- a/examples/locust/basic.py
+++ b/examples/locust/basic.py
@@ -1,0 +1,9 @@
+from locust import HttpUser, between, task
+
+
+class WebsiteUser(HttpUser):
+    wait_time = between(5, 15)
+
+    @task
+    def index(self):
+        self.client.get("/")

--- a/examples/locust/cloud-event.json
+++ b/examples/locust/cloud-event.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "deployment": {
+      "deploymentURIsPublic": [
+        "https://keptn.sh"
+      ]
+    },
+    "project": "jes-locust",
+    "service": "helloservice",
+    "stage": "qa"
+  },
+  "source": "jes-examples-readme",
+  "specversion": "1.0",
+  "shkeptnspecversion": "0.2.3",
+  "type": "sh.keptn.event.qa.test.triggered"
+}

--- a/examples/locust/job-config.yaml
+++ b/examples/locust/job-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+actions:
+  - name: "Run tests using locust"
+    events:
+      - name: "sh.keptn.event.test.triggered"
+    tasks:
+      - name: "Run locust"
+        files:
+          - locust/basic.py
+          - locust/locust.conf
+        image: "locustio/locust"
+        cmd: ["locust"]
+        args: ["--config", "/keptn/locust/locust.conf", "-f", "/keptn/locust/basic.py", "--host", "$(HOST)", "--only-summary"]
+        env:
+          - name: HOST
+            value: "$.data.deployment.deploymentURIsPublic[0]"
+            valueFrom: event

--- a/examples/locust/locust.conf
+++ b/examples/locust/locust.conf
@@ -1,0 +1,4 @@
+locustfile = /locust/locust.py
+headless = true
+users = 10
+run-time = 2m

--- a/examples/locust/shipyard.yaml
+++ b/examples/locust/shipyard.yaml
@@ -1,0 +1,11 @@
+apiVersion: spec.keptn.sh/0.2.2
+kind: "Shipyard"
+metadata:
+  name: "shipyard-locust"
+spec:
+  stages:
+    - name: "qa"
+      sequences:
+        - name: "test"
+          tasks:
+            - name: "test"


### PR DESCRIPTION
## This PR

- Adds more examples, including a basic hello-world example ([preview](https://github.com/keptn-contrib/job-executor-service/tree/patch/examples/examples))

All examples have been tried out with Keptn 0.12.6.


