### PR TITLE
build: Add api-token to skaffold.yaml for better dev experience

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -29,6 +29,10 @@ deploy:
             image: keptncontrib/job-executor-service-initcontainer
         imageStrategy:
           helm: { }
+        setValueTemplates:
+          remoteControlPlane:
+            api:
+              token: "{{.KEPTN_API_TOKEN}}" # please set KEPTN_API_TOKEN as an environment variable
         overrides:
           distributor:
             image:


### PR DESCRIPTION
Until https://github.com/keptn-contrib/job-executor-service/issues/209 gets implemented, we can leverage this simple change to have an API token set as an environment variable when running skaffold.

See https://skaffold.dev/docs/environment/templating/ for more infos on templating with skaffold.

Example to run:

```bash
KEPTN_API_TOKEN=abcd skaffold run --tail
```

Or even better
```bash
KEPTN_API_TOKEN=$(kubectl get secret keptn-api-token -n keptn -ojsonpath='{.data.keptn-api-token}' | base64 -d) skaffold run --tail
```