### PR TITLE
feat: Include logs of all containers in error message

### DIFF
--- a/pkg/eventhandler/fake/eventhandlers_mock.go
+++ b/pkg/eventhandler/fake/eventhandlers_mock.go
@@ -193,6 +193,20 @@ func (mr *MockK8sMockRecorder) CreateK8sJob(arg0, arg1, arg2, arg3, arg4, arg5, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateK8sJob", reflect.TypeOf((*MockK8s)(nil).CreateK8sJob), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
+// ExistsServiceAccount mocks base method.
+func (m *MockK8s) ExistsServiceAccount(arg0, arg1 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExistsServiceAccount", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ExistsServiceAccount indicates an expected call of ExistsServiceAccount.
+func (mr *MockK8sMockRecorder) ExistsServiceAccount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistsServiceAccount", reflect.TypeOf((*MockK8s)(nil).ExistsServiceAccount), arg0, arg1)
+}
+
 // GetLogsOfPod mocks base method.
 func (m *MockK8s) GetLogsOfPod(arg0, arg1 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -442,3 +442,13 @@ func (k8s *K8sImpl) generateEnvFromSecret(env config.Env, namespace string) ([]v
 
 	return generatedEnv, nil
 }
+
+// ExistsServiceAccount returns true of the given service account exists in the namespace
+func (k8s *K8sImpl) ExistsServiceAccount(saName string, namespace string) bool {
+	_, err := k8s.clientset.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), saName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -442,13 +442,3 @@ func (k8s *K8sImpl) generateEnvFromSecret(env config.Env, namespace string) ([]v
 
 	return generatedEnv, nil
 }
-
-// ExistsServiceAccount returns true of the given service account exists in the namespace
-func (k8s *K8sImpl) ExistsServiceAccount(saName string, namespace string) bool {
-	_, err := k8s.clientset.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), saName, metav1.GetOptions{})
-	if err != nil {
-		return false
-	}
-
-	return true
-}

--- a/pkg/k8sutils/pod.go
+++ b/pkg/k8sutils/pod.go
@@ -27,51 +27,38 @@ func (k8s *K8sImpl) GetLogsOfPod(jobName string, namespace string) (string, erro
 
 	for _, pod := range list.Items {
 
+		printInitContainerLogs := false
+		containerStatus := getTerminatedContainersWithStatusOfPod(pod)
+
+		// Go through all containers and check if the termination reason is Completed, if not we found a container
+		// that exited with an error and therefore have to include all logs from init container, as files could not
+		// have been copied over
+		for _, container := range containerStatus {
+			if container.status.Reason != "Completed" {
+				printInitContainerLogs = true
+				break
+			}
+		}
+
 		// Query all logs from containers that have terminated and therefore already had the chance to
 		// produce logs, otherwise the k8s api will return an error
-		for _, container := range getTerminatedContainersWithStatusOfPod(pod) {
+		for _, container := range containerStatus {
+
+			// If we don't want to print the init container logs, we just skip this iteration of the
+			// loop
+			if container.containerType == initContainerType && !printInitContainerLogs {
+				continue
+			}
 
 			// Query logs of the current selected container
 			logsOfContainer, err := getLogsOfContainer(k8s, pod, namespace, container.name)
 			if err != nil {
-				return "", err
+				// In case we can't query the logs of a container, we append the reason instead of the container logs
+				logsOfContainer = fmt.Sprintf("Unable to query logs of container: %s", err.Error())
 			}
 
-			// Prepend the container name at the beginning, so we are able to separate logs of different containers
-			// and display a termination error at the beginning, may be more interesting than the logs of the container
-			if container.status.Reason != "Completed" {
-				logs.WriteString("Container ")
-				logs.WriteString(container.name)
-				logs.WriteString(" terminated with an error (Reason: ")
-				logs.WriteString(container.status.Reason)
-
-				// Sometimes the message is not given, to provide prettier logs we just don't print the
-				// message part if it doesn't exist
-				if container.status.Message != "" {
-					logs.WriteString(", Message: ")
-					logs.WriteString(container.status.Message)
-					logs.WriteString(")")
-				} else {
-					logs.WriteString(", ExitCode: ")
-					logs.WriteString(fmt.Sprintf("%d", container.status.ExitCode))
-					logs.WriteString(")")
-				}
-
-				logs.WriteString(":\n")
-			} else {
-				logs.WriteString("Container ")
-				logs.WriteString(container.name)
-				logs.WriteString(":\n")
-			}
-
-			// Finally, append the actual logs of the container or a default message to the log
-			if logsOfContainer != "" {
-				logs.WriteString(logsOfContainer)
-				logs.WriteString("\n")
-			} else {
-				logs.WriteString("<no logs available for container>\n")
-			}
-
+			// Build the final logging output for the container
+			logs.WriteString(buildLogOutputForContainer(container, logsOfContainer))
 			logs.WriteString("\n")
 		}
 	}
@@ -79,16 +66,28 @@ func (k8s *K8sImpl) GetLogsOfPod(jobName string, namespace string) (string, erro
 	return logs.String(), nil
 }
 
+const (
+	// Indicates that the container is an Init container
+	initContainerType = iota
+	// Indicates that the container is a container defined in the job workload
+	jobContainerType
+)
+
 type containerStatus struct {
-	name   string
-	status *v1.ContainerStateTerminated
+	name          string
+	containerType int
+	status        *v1.ContainerStateTerminated
 }
 
+// getLogsOfContainer returns the logs of a specific container inside the given pod
 func getLogsOfContainer(k8s *K8sImpl, pod v1.Pod, namespace string, container string) (string, error) {
+
+	// Request logs of a specific container
 	req := k8s.clientset.CoreV1().Pods(namespace).GetLogs(pod.Name, &v1.PodLogOptions{
 		Container: container,
 	})
 
+	// Stream logs into a buffer
 	podLogs, err := req.Stream(context.TODO())
 	if err != nil {
 		return "", err
@@ -96,6 +95,7 @@ func getLogsOfContainer(k8s *K8sImpl, pod v1.Pod, namespace string, container st
 
 	defer podLogs.Close()
 
+	// Convert the buffer into a string
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)
 	if err != nil {
@@ -105,26 +105,87 @@ func getLogsOfContainer(k8s *K8sImpl, pod v1.Pod, namespace string, container st
 	return buf.String(), nil
 }
 
+// getTerminatedContainersWithStatusOfPod collects the terminated states of all containers inside a given Pod
 func getTerminatedContainersWithStatusOfPod(pod v1.Pod) []containerStatus {
 	var containerStatusList []containerStatus
 
+	// Loop over all initContainers in the Pod spec and look at the appropriate
+	// InitContainerStatus index to determine the status of the init container
 	for index, initContainer := range pod.Spec.InitContainers {
 		if pod.Status.InitContainerStatuses[index].State.Terminated != nil {
 			containerStatusList = append(containerStatusList, containerStatus{
-				name:   initContainer.Name,
-				status: pod.Status.InitContainerStatuses[index].State.Terminated,
+				name:          initContainer.Name,
+				containerType: initContainerType,
+				status:        pod.Status.InitContainerStatuses[index].State.Terminated,
 			})
 		}
 	}
 
+	// Loop over all regular containers in the Pod spec and look at the appropriate
+	// ContainerStatus index to determine the status of the container
 	for index, container := range pod.Spec.Containers {
 		if pod.Status.ContainerStatuses[index].State.Terminated != nil {
 			containerStatusList = append(containerStatusList, containerStatus{
-				name:   container.Name,
-				status: pod.Status.ContainerStatuses[index].State.Terminated,
+				name:          container.Name,
+				containerType: jobContainerType,
+				status:        pod.Status.ContainerStatuses[index].State.Terminated,
 			})
 		}
 	}
 
 	return containerStatusList
+}
+
+// buildLogOutputForContainer generates a pretty output of the given logs and the container status in the following
+// format. Depending on the status the output changes slightly (output will be empty of no logs are produced):
+//
+// - Normal output:
+// 		Container <container.name>:
+//  	<logsOfContainer>
+//
+// - In case of an error:
+// 		Container <container.name> terminated with an error (Reason: <reason> [, Message: <message> |, ExitCode: <code>]):
+// 		<logsOfContainer>
+//
+func buildLogOutputForContainer(container containerStatus, logsOfContainer string) string {
+	var logs strings.Builder
+
+	// If the container did not put out any logs, we skip it entirely to prevent polluting the
+	// log output too much by appending <no logs available for container> for each container
+	if logsOfContainer == "" {
+		return ""
+	}
+
+	// Prepend the container name at the beginning, so we are able to separate logs of different containers
+	// and display a termination error at the beginning, may be more interesting than the logs of the container
+	if container.status.Reason != "Completed" {
+		logs.WriteString("Container ")
+		logs.WriteString(container.name)
+		logs.WriteString(" terminated with an error (Reason: ")
+		logs.WriteString(container.status.Reason)
+
+		// Sometimes the message is not given, to provide prettier logs we just don't print the
+		// message part if it doesn't exist
+		if container.status.Message != "" {
+			logs.WriteString(", Message: ")
+			logs.WriteString(container.status.Message)
+			logs.WriteString(")")
+		} else {
+			logs.WriteString(", ExitCode: ")
+			logs.WriteString(fmt.Sprintf("%d", container.status.ExitCode))
+			logs.WriteString(")")
+		}
+
+		logs.WriteString(":\n")
+	} else {
+		logs.WriteString("Container ")
+		logs.WriteString(container.name)
+		logs.WriteString(":\n")
+	}
+
+	// Finally, append the actual logs of the container or a default message to the log
+	logs.WriteString(logsOfContainer)
+	logs.WriteString("\n")
+
+	return logs.String()
 }

--- a/pkg/k8sutils/pod.go
+++ b/pkg/k8sutils/pod.go
@@ -3,18 +3,16 @@ package k8sutils
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
 
 // GetLogsOfPod returns the k8s logs of a job in a namespace
 func (k8s *K8sImpl) GetLogsOfPod(jobName string, namespace string) (string, error) {
-
-	// TODO include the logs of the initcontainer
-
-	podLogOpts := v1.PodLogOptions{}
 
 	list, err := k8s.clientset.CoreV1().Pods(namespace).List(
 		context.TODO(), metav1.ListOptions{
@@ -25,24 +23,108 @@ func (k8s *K8sImpl) GetLogsOfPod(jobName string, namespace string) (string, erro
 		return "", err
 	}
 
-	logs := ""
+	var logs strings.Builder
 
 	for _, pod := range list.Items {
 
-		req := k8s.clientset.CoreV1().Pods(namespace).GetLogs(pod.Name, &podLogOpts)
-		podLogs, err := req.Stream(context.TODO())
-		if err != nil {
-			return "", err
-		}
-		defer podLogs.Close()
+		// Query all logs from containers that have terminated and therefore already had the chance to
+		// produce logs, otherwise the k8s api will return an error
+		for _, container := range getTerminatedContainersWithStatusOfPod(pod) {
 
-		buf := new(bytes.Buffer)
-		_, err = io.Copy(buf, podLogs)
-		if err != nil {
-			return "", err
+			// Query logs of the current selected container
+			logsOfContainer, err := getLogsOfContainer(k8s, pod, namespace, container.name)
+			if err != nil {
+				return "", err
+			}
+
+			// Prepend the container name at the beginning, so we are able to separate logs of different containers
+			// and display a termination error at the beginning, may be more interesting than the logs of the container
+			if container.status.Reason != "Completed" {
+				logs.WriteString("Container ")
+				logs.WriteString(container.name)
+				logs.WriteString(" terminated with an error (Reason: ")
+				logs.WriteString(container.status.Reason)
+
+				// Sometimes the message is not given, to provide prettier logs we just don't print the
+				// message part if it doesn't exist
+				if container.status.Message != "" {
+					logs.WriteString(", Message: ")
+					logs.WriteString(container.status.Message)
+					logs.WriteString(")")
+				} else {
+					logs.WriteString(", ExitCode: ")
+					logs.WriteString(fmt.Sprintf("%d", container.status.ExitCode))
+					logs.WriteString(")")
+				}
+
+				logs.WriteString(":\n")
+			} else {
+				logs.WriteString("Container ")
+				logs.WriteString(container.name)
+				logs.WriteString(":\n")
+			}
+
+			// Finally, append the actual logs of the container or a default message to the log
+			if logsOfContainer != "" {
+				logs.WriteString(logsOfContainer)
+				logs.WriteString("\n")
+			} else {
+				logs.WriteString("<no logs available for container>\n")
+			}
+
+			logs.WriteString("\n")
 		}
-		logs += buf.String()
 	}
 
-	return logs, nil
+	return logs.String(), nil
+}
+
+type containerStatus struct {
+	name   string
+	status *v1.ContainerStateTerminated
+}
+
+func getLogsOfContainer(k8s *K8sImpl, pod v1.Pod, namespace string, container string) (string, error) {
+	req := k8s.clientset.CoreV1().Pods(namespace).GetLogs(pod.Name, &v1.PodLogOptions{
+		Container: container,
+	})
+
+	podLogs, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", err
+	}
+
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func getTerminatedContainersWithStatusOfPod(pod v1.Pod) []containerStatus {
+	var containerStatusList []containerStatus
+
+	for index, initContainer := range pod.Spec.InitContainers {
+		if pod.Status.InitContainerStatuses[index].State.Terminated != nil {
+			containerStatusList = append(containerStatusList, containerStatus{
+				name:   initContainer.Name,
+				status: pod.Status.InitContainerStatuses[index].State.Terminated,
+			})
+		}
+	}
+
+	for index, container := range pod.Spec.Containers {
+		if pod.Status.ContainerStatuses[index].State.Terminated != nil {
+			containerStatusList = append(containerStatusList, containerStatus{
+				name:   container.Name,
+				status: pod.Status.ContainerStatuses[index].State.Terminated,
+			})
+		}
+	}
+
+	return containerStatusList
 }

--- a/pkg/k8sutils/pod_test.go
+++ b/pkg/k8sutils/pod_test.go
@@ -124,10 +124,10 @@ func TestGetLogsOfPodHappyPath(t *testing.T) {
 
 	logsOfPod, err := k8s.GetLogsOfPod(jobName, namespace)
 	assert.NoError(t, err)
-	assert.Equal(t, logsOfPod, "fake logs")
+	assert.Contains(t, logsOfPod, "fake logs")
 
 	// Assert that the fake received the call
-	getLogAction := k8stesting.GenericActionImpl{
+	getLogActionInitContainer := k8stesting.GenericActionImpl{
 		ActionImpl: k8stesting.ActionImpl{
 			Namespace: namespace,
 			Verb:      "get",
@@ -138,8 +138,27 @@ func TestGetLogsOfPodHappyPath(t *testing.T) {
 			},
 			Subresource: "log",
 		},
-		Value: &v1.PodLogOptions{},
+		Value: &v1.PodLogOptions{
+			Container: initContainerName,
+		},
 	}
 
-	assert.Contains(t, k8sClientSet.Actions(), getLogAction)
+	getLogActionContainer := k8stesting.GenericActionImpl{
+		ActionImpl: k8stesting.ActionImpl{
+			Namespace: namespace,
+			Verb:      "get",
+			Resource: schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
+			Subresource: "log",
+		},
+		Value: &v1.PodLogOptions{
+			Container: jobName,
+		},
+	}
+
+	assert.Contains(t, k8sClientSet.Actions(), getLogActionInitContainer)
+	assert.Contains(t, k8sClientSet.Actions(), getLogActionContainer)
 }


### PR DESCRIPTION
## This PR
* improves the debugging experience by including all logs of all containers in a pod when reporting back the logs (related to #123)
* adds the failure reason and message / exit code of a container to the error log 

## Solves
* #124


