### PR TITLE
docs: Provide incompatibility warning for Keptn 0.14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ running in the Keptn ecosystem:
 |    0.12.2     |                               keptncontrib/job-executor-service:0.1.7                                |       v2       |
 |    0.12.6     |                               keptncontrib/job-executor-service:0.1.8                                |       v2       |
 
-
 Please note: Newer Keptn versions might be compatible, but compatibility has not been verified at the time of the release.
+
+**Warning**: We are aware that there might be a problem when trying to install Job-Executor-Service in the same namespace as Keptn 0.14.x. 
+For now, we advise to install Job-Executor-Service in a separate namespace, and set `remoteControlPlane.api.hostname`, `remoteControlPlane.api.token`, ... as detailed in the
+[Installation section](#installation) below.
+
 
 <details>
   <summary>Click here to show older versions</summary>


### PR DESCRIPTION
Installing Job-Executor-Service with Keptn 0.14.x should work, but it requires us to use "remote execution-plane" setup (which is the default in the current master branch).