### PR TITLE
feat: Upgrade to Keptn 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ running in the Keptn ecosystem:
 |    0.10.0     |                               keptncontrib/job-executor-service:0.1.6                                |       v2       |
 |    0.12.2     |                               keptncontrib/job-executor-service:0.1.7                                |       v2       |
 |    0.12.6     |                               keptncontrib/job-executor-service:0.1.8                                |       v2       |
+|    0.13.x     |                               keptncontrib/job-executor-service:0.1.9                                |       v2       |
 
 Please note: Newer Keptn versions might be compatible, but compatibility has not been verified at the time of the release.
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,7 +18,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.12.6"                             # Container Tag
+    tag: "0.13.4"                             # Container Tag
   config:
     queueGroup:
       enabled: true                          # Enable connection via Nats queue group to support exactly-once message processing

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.12.0
+	github.com/keptn/go-utils v0.13.0
 	github.com/keptn/kubernetes-utils v0.12.0
 	github.com/spf13/afero v1.8.2
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -491,6 +491,8 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keptn/go-utils v0.10.0/go.mod h1:ub4G0WZUckc3TizUoe5jKqfCOOLiH5pnf4M1SDCOT0M=
 github.com/keptn/go-utils v0.12.0 h1:iB/2qDJLt0V2OwkSAD4rH0lKEGlKyYNLzS/ZZ6HKZfY=
 github.com/keptn/go-utils v0.12.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/go-utils v0.13.0 h1:jQ8EoWWa4EPamu4dis+AMzVD4YG2Yu/FEwvpgwslFrE=
+github.com/keptn/go-utils v0.13.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
 github.com/keptn/kubernetes-utils v0.12.0 h1:fONOVQY2KXKMxvxAZMCIbyWYzuo714k9gS2MGsp/+wM=
 github.com/keptn/kubernetes-utils v0.12.0/go.mod h1:vSj1n58CWHBrh4DzMhODGU1Z6BKYl9wEFzsg4XmuaJ0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -36,7 +36,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.12.6
+              tag: 0.13.4
             securityContext:
               seccompProfile:
                 type: Unconfined # needed for debugging


### PR DESCRIPTION
## This PR

- Upgrades distributor to Keptn 0.13.4
- Upgrades go-utils to v0.13
- Updates compatibility matrix 