### PR TITLE
fix: Job cleanup integration test

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -38,6 +38,13 @@ rules:
       - "get"
       - "create"
       - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "list"
+      - "get"
 ---
 # Bind role for accessing secrets onto the job-executor-service service account
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/jobcleanup_test.go
+++ b/test/e2e/jobcleanup_test.go
@@ -73,8 +73,6 @@ func TestJobCleanupWithSmallTTL(t *testing.T) {
 }
 
 func TestJobCleanupWith0TTLMultipleJobs(t *testing.T) {
-	t.Skip("Skipping TestJobCleanupWith0TTLMultipleJobs since TTL=0 is not currently supported/working")
-
 	if !isE2ETestingAllowed() {
 		t.Skip("Skipping TestJobCleanupWith0TTLMultipleJobs, not allowed by environment")
 	}
@@ -108,8 +106,6 @@ func TestJobCleanupWith0TTLMultipleJobs(t *testing.T) {
 	)
 
 	// If the started event was sent by the job executor we wait for a .finished with the following data:
-
-	// TODO: This is set to fail because JES can never collect logs of jobs with TTL 0s
 	expectedEventData := eventData{
 		Project: testEnv.EventData.Project,
 		Result:  "pass",


### PR DESCRIPTION
## This PR
* implements a fix such that JES reports the status correctly for jobs that will be collected instantly
* enables the Job cleanup test with TTL 0