### PR TITLE
feat: limit job run time

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -9,42 +9,43 @@ Helm Chart for the keptn job-executor-service
 
 The following table lists the configurable parameters of the job-executor-service chart and their default values.
 
-| Parameter                               | Description             | Default       |
-|-----------------------------------------| ----------------------- | ------------- |
-| `jobexecutorservice.image.repository`   | Container image name | `"docker.io/keptncontrib/job-executor-service"` |
-| `jobexecutorservice.image.pullPolicy`   | Kubernetes image pull policy | `"IfNotPresent"` |
-| `jobexecutorservice.image.tag`          | Container tag | `""` |
-| `jobexecutorservice.service.enabled`    | Creates a kubernetes service for the job-executor-service | `true` |
-| `distributor.stageFilter`               | Sets the stage this helm service belongs to | `""` |
-| `distributor.serviceFilter`             | Sets the service this helm service belongs to | `""` |
-| `distributor.projectFilter`             | Sets the project this helm service belongs to | `""` |
-| `distributor.image.repository`          | Container image name | `"docker.io/keptn/distributor"` |
-| `distributor.image.pullPolicy`          | Kubernetes image pull policy | `"IfNotPresent"` |
-| `distributor.image.tag`                 | Container tag | `""` |
-| `jobConfig.allowedImageList`            | A comma sperated list of images that are allowed in job workloads | `""` |
-| `jobConfig.allowPrivilegedJobs`         | Allows privileged job workloads. ***Allowing privileged job workloads can be considered dangerous!*** | `false` |
-| `jobConfig.podSecurityContext`          | The default pod security context for job workloads | [See values.yaml](values.yaml)  |
-| `jobConfig.jobSecurityContext`          | The default security context for job workloads | [See values.yaml](values.yaml) |
-| `jobConfig.serviceAccount.create`       | Enables the creation of the default service account used for job workloads | `true` | 
-| `jobConfig.serviceAccount.name`         | The name of the default service account used for job workloads | `default-job-account` | 
-| `jobConfig.serviceAccount.annotations`  | Additional annotations for the default service account used for job workloads | `{}` |
-| `remoteControlPlane.autoDetect.enabled`   | Enables auto detection of a Keptn installation | `false` |
-| `remoteControlPlane.autoDetect.namespace` | Namespace which should be used by the auto-detection | `""` |
-| `remoteControlPlane.api.protocol`       | Used protocol (http, https | `"https"` |
-| `remoteControlPlane.api.hostname`       | Hostname of the control plane cluster (and port) | `"api-gateway-nginx.keptn"` |
-| `remoteControlPlane.api.apiValidateTls` | Defines if the control plane certificate should be validated | `true` |
-| `remoteControlPlane.api.token`          | Keptn api token | `""` |
-| `imagePullSecrets`                      | Secrets to use for container registry credentials | `[]` |
-| `serviceAccount.create`                 | Enables the service account creation | `true` |
-| `serviceAccount.annotations`            | Annotations to add to the service account | `{}` |
-| `serviceAccount.name`                   | The name of the service account to use. | `""` |
-| `podAnnotations`                        | Annotations to add to the created pods | `{}` |
-| `podSecurityContext`                    | Set the pod security context. ***For security purposes the podSecurityContext value should not be changed!*** | [See values.yaml](values.yaml)           |
-| `securityContext`                       | Set the security context. ***For security purposes the securityContext value should not be changed!***        | [See values.yaml](values.yaml) |
-| `resources`                             | Resource limits and requests | `{}` |
-| `nodeSelector`                          | Node selector configuration | `{}` |
-| `tolerations`                           | Tolerations for the pods | `[]` |
-| `affinity`                              | Affinity rules | `{}` |
+| Parameter                                 | Description                                                                                                     | Default                                         |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| `jobexecutorservice.image.repository`     | Container image name                                                                                            | `"docker.io/keptncontrib/job-executor-service"` |
+| `jobexecutorservice.image.pullPolicy`     | Kubernetes image pull policy                                                                                    | `"IfNotPresent"`                                |
+| `jobexecutorservice.image.tag`            | Container tag                                                                                                   | `""`                                            |
+| `jobexecutorservice.service.enabled`      | Creates a kubernetes service for the job-executor-service                                                       | `true`                                          |
+| `distributor.stageFilter`                 | Sets the stage this helm service belongs to                                                                     | `""`                                            |
+| `distributor.serviceFilter`               | Sets the service this helm service belongs to                                                                   | `""`                                            |
+| `distributor.projectFilter`               | Sets the project this helm service belongs to                                                                   | `""`                                            |
+| `distributor.image.repository`            | Container image name                                                                                            | `"docker.io/keptn/distributor"`                 |
+| `distributor.image.pullPolicy`            | Kubernetes image pull policy                                                                                    | `"IfNotPresent"`                                |
+| `distributor.image.tag`                   | Container tag                                                                                                   | `""`                                            |
+| `jobConfig.allowedImageList`              | A comma sperated list of images that are allowed in job workloads                                               | `""`                                            |
+| `jobConfig.allowPrivilegedJobs`           | Allows privileged job workloads. ***Allowing privileged job workloads can be considered dangerous!***           | `false`                                         |
+| `jobConfig.podSecurityContext`            | The default pod security context for job workloads                                                              | [See values.yaml](values.yaml)                  |
+| `jobConfig.jobSecurityContext`            | The default security context for job workloads                                                                  | [See values.yaml](values.yaml)                  |
+| `jobConfig.serviceAccount.create`         | Enables the creation of the default service account used for job workloads                                      | `true`                                          | 
+| `jobConfig.serviceAccount.name`           | The name of the default service account used for job workloads                                                  | `default-job-account`                           | 
+| `jobConfig.serviceAccount.annotations`    | Additional annotations for the default service account used for job workloads                                   | `{}`                                            |
+| `jobConfig.taskDeadlineSeconds`           | Maximum duration for a kubernetes job run in seconds (0 means no limit, set it to an integer > 0 to enforce it) | `0`                                             |
+| `remoteControlPlane.autoDetect.enabled`   | Enables auto detection of a Keptn installation                                                                  | `false`                                         |
+| `remoteControlPlane.autoDetect.namespace` | Namespace which should be used by the auto-detection                                                            | `""`                                            |
+| `remoteControlPlane.api.protocol`         | Used protocol (http, https                                                                                      | `"https"`                                       |
+| `remoteControlPlane.api.hostname`         | Hostname of the control plane cluster (and port)                                                                | `"api-gateway-nginx.keptn"`                     |
+| `remoteControlPlane.api.apiValidateTls`   | Defines if the control plane certificate should be validated                                                    | `true`                                          |
+| `remoteControlPlane.api.token`            | Keptn api token                                                                                                 | `""`                                            |
+| `imagePullSecrets`                        | Secrets to use for container registry credentials                                                               | `[]`                                            |
+| `serviceAccount.create`                   | Enables the service account creation                                                                            | `true`                                          |
+| `serviceAccount.annotations`              | Annotations to add to the service account                                                                       | `{}`                                            |
+| `serviceAccount.name`                     | The name of the service account to use.                                                                         | `""`                                            |
+| `podAnnotations`                          | Annotations to add to the created pods                                                                          | `{}`                                            |
+| `podSecurityContext`                      | Set the pod security context. ***For security purposes the podSecurityContext value should not be changed!***   | [See values.yaml](values.yaml)                  |
+| `securityContext`                         | Set the security context. ***For security purposes the securityContext value should not be changed!***          | [See values.yaml](values.yaml)                  |
+| `resources`                               | Resource limits and requests                                                                                    | `{}`                                            |
+| `nodeSelector`                            | Node selector configuration                                                                                     | `{}`                                            |
+| `tolerations`                             | Tolerations for the pods                                                                                        | `[]`                                            |
+| `affinity`                                | Affinity rules                                                                                                  | `{}`                                            |
 
 
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -14,3 +14,4 @@ data:
   init_container_configuration_endpoint: {{ include "job-executor-service.remote-control-plane.configuration-endpoint" . }}
   default_job_service_account: "{{ include "job-executor-service.jobConfig.serviceAccountName" . }}"
   allow_privileged_jobs: "{{ .Values.jobConfig.allowPrivilegedJobs | default "false" }}"
+  task_deadline_seconds: {{ .Values.jobConfig.taskDeadlineSeconds | default 0 | quote}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -108,6 +108,11 @@ spec:
               configMapKeyRef:
                 name: job-service-config
                 key: allow_privileged_jobs
+          - name: TASK_DEADLINE_SECONDS
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: task_deadline_seconds
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: distributor

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,6 +69,7 @@ jobConfig:
       drop: [ "all" ]
     seccompProfile:
       type: RuntimeDefault
+  taskDeadlineSeconds: 0                     # Set taskDeadlineSeconds to an integer > 0 to limit how long task can run
 
 imagePullSecrets: [ ]                        # Secrets to use for container registry credentials
 

--- a/pkg/k8sutils/job.go
+++ b/pkg/k8sutils/job.go
@@ -34,6 +34,8 @@ const envValueFromString = "string"
 const minTTLSecondsAfterFinished = int32(60)
 const defaultTTLSecondsAfterFinished = int32(21600)
 
+const reasonJobDeadlineExceeded = "DeadlineExceeded"
+
 // ErrPrivilegedContainerNotAllowed indicates an error that occurs if a security context does contain privileged=true
 // but the policy of the job-executor-service doesn't allow such job workloads to be created
 var /*const*/ ErrPrivilegedContainerNotAllowed = errors.New("privileged containers are not allowed")
@@ -318,7 +320,7 @@ func (k8s *K8sImpl) AwaitK8sJobDone(
 					"job %s was suspended. Reason: %s, Message: %s", jobName, condition.Reason, condition.Message,
 				)
 			case batchv1.JobFailed:
-				if condition.Reason == "DeadlineExceeded" {
+				if condition.Reason == reasonJobDeadlineExceeded {
 					return fmt.Errorf("job %s failed: %w", jobName, ErrTaskDeadlineExceeded)
 				}
 

--- a/pkg/k8sutils/job_test.go
+++ b/pkg/k8sutils/job_test.go
@@ -693,7 +693,7 @@ func TestAwaitK8sJobDoneErrorJobFailed(t *testing.T) {
 var Deadline30Sec = int64(30)
 var ExpectedDeadline30Sec = int64(30)
 
-func TestTaskDeadlineSeconds(t *testing.T) {
+func TestCreateJobTaskDeadlineSeconds(t *testing.T) {
 	k8sClientSet := k8sfake.NewSimpleClientset()
 	k8s := K8sImpl{clientset: k8sClientSet}
 
@@ -847,7 +847,7 @@ func TestAwaitK8sJobExceededDeadline(t *testing.T) {
 				{
 					Type:    v1.JobFailed,
 					Status:  corev1.ConditionTrue,
-					Reason:  "DeadlineExceeded",
+					Reason:  reasonJobDeadlineExceeded,
 					Message: "Job exceeded deadline",
 				},
 			},

--- a/pkg/k8sutils/job_test.go
+++ b/pkg/k8sutils/job_test.go
@@ -690,6 +690,76 @@ func TestAwaitK8sJobDoneErrorJobFailed(t *testing.T) {
 	)
 }
 
+var Deadline30Sec = int64(30)
+var ExpectedDeadline30Sec = int64(30)
+
+func TestTaskDeadlineSeconds(t *testing.T) {
+	k8sClientSet := k8sfake.NewSimpleClientset()
+	k8s := K8sImpl{clientset: k8sClientSet}
+
+	tests := []struct {
+		name                          string
+		taskDeadlineSeconds           *int64
+		expectedActiveDeadlineSeconds *int64
+	}{
+		{
+			name:                          "No deadline specified, no limit set in job",
+			taskDeadlineSeconds:           nil,
+			expectedActiveDeadlineSeconds: nil,
+		},
+		{
+			name:                          "30sec deadline",
+			taskDeadlineSeconds:           &Deadline30Sec,
+			expectedActiveDeadlineSeconds: &ExpectedDeadline30Sec,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(
+			test.name, func(t *testing.T) {
+				jobName := fmt.Sprintf("tds-job-%d", i)
+				task := config.Task{
+					Name:  fmt.Sprintf("TdsTask-%d", i),
+					Image: "someImage:someversion",
+					Cmd:   []string{"someCmd"},
+				}
+
+				eventData := keptnv2.EventData{
+					Project: "keptnproject",
+					Stage:   "dev",
+					Service: "keptnservice",
+				}
+
+				namespace := "test-namespace"
+
+				jobSettings := JobSettings{
+					JobNamespace: namespace,
+					DefaultResourceRequirements: &corev1.ResourceRequirements{
+						Limits:   make(corev1.ResourceList),
+						Requests: make(corev1.ResourceList),
+					},
+					DefaultPodSecurityContext: new(corev1.PodSecurityContext),
+					DefaultSecurityContext:    new(corev1.SecurityContext),
+					TaskDeadlineSeconds:       test.taskDeadlineSeconds,
+				}
+				err := k8s.CreateK8sJob(
+					jobName, &config.Action{Name: fmt.Sprintf("test-action-%d", i)}, task, &eventData, jobSettings, "",
+					namespace,
+				)
+
+				require.NoError(t, err, "Error creating test job")
+
+				job, err := k8sClientSet.BatchV1().Jobs(namespace).Get(
+					context.Background(), jobName, metav1.GetOptions{},
+				)
+
+				require.NoError(t, err, "Error retrieving created test job")
+				assert.Equal(t, test.expectedActiveDeadlineSeconds, job.Spec.ActiveDeadlineSeconds)
+			},
+		)
+	}
+}
+
 func TestAwaitK8sJobDoneErrorJobSuspended(t *testing.T) {
 	k8sClientSet := k8sfake.NewSimpleClientset()
 	k8s := K8sImpl{clientset: k8sClientSet}
@@ -741,10 +811,8 @@ func TestAwaitK8sJobDoneErrorNeverComplete(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: jobName,
 		},
-		Spec: v1.JobSpec{},
-		Status: v1.JobStatus{
-			Conditions: []v1.JobCondition{},
-		},
+		Spec:   v1.JobSpec{},
+		Status: v1.JobStatus{},
 	}
 	namespace := "never-ending-jobs-land"
 	k8sClientSet.BatchV1().Jobs(namespace).Create(
@@ -757,9 +825,48 @@ func TestAwaitK8sJobDoneErrorNeverComplete(t *testing.T) {
 
 	assert.ErrorContains(
 		t, err, fmt.Sprintf(
-			"max poll count reached for job %s. Timing out after", jobName,
+			"polling for job %s timing out after", jobName,
 		),
 	)
+
+	assert.ErrorIs(t, err, ErrMaxPollTimeExceeded)
+}
+
+func TestAwaitK8sJobExceededDeadline(t *testing.T) {
+	k8sClientSet := k8sfake.NewSimpleClientset()
+	k8s := K8sImpl{clientset: k8sClientSet}
+
+	jobName := "deadline-exceeding-job"
+	job := v1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: jobName,
+		},
+		Spec: v1.JobSpec{},
+		Status: v1.JobStatus{
+			Conditions: []v1.JobCondition{
+				{
+					Type:    v1.JobFailed,
+					Status:  corev1.ConditionTrue,
+					Reason:  "DeadlineExceeded",
+					Message: "Job exceeded deadline",
+				},
+			},
+		},
+	}
+	namespace := "tight-job-runtimes-only"
+	k8sClientSet.BatchV1().Jobs(namespace).Create(
+		context.Background(), &job, metav1.CreateOptions{},
+	)
+
+	err := k8s.AwaitK8sJobDone(jobName, 500*time.Millisecond, 50*time.Millisecond, namespace)
+
+	require.Error(t, err)
+
+	assert.ErrorContains(
+		t, err, fmt.Sprintf("job %s failed:", jobName),
+	)
+
+	assert.ErrorIs(t, err, ErrTaskDeadlineExceeded)
 }
 
 func TestAwaitK8sJobDoneSuccessAfterPolling(t *testing.T) {

--- a/test/data/e2e/taskdeadline.config.yaml
+++ b/test/data/e2e/taskdeadline.config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+actions:
+  - name: "Job cleanup e2e test"
+    events:
+      - name: "sh.keptn.event.deployment.triggered"
+    tasks:
+      - name: "Sleep a while"
+        ttlSecondsAfterFinished: 5
+        image: "alpine"
+        cmd:
+          - sh
+        args:
+          - "-c"
+          - "sleep $LABELS_SLEEP && echo sleeping done"

--- a/test/e2e/taskdeadline_test.go
+++ b/test/e2e/taskdeadline_test.go
@@ -1,0 +1,182 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keptn/go-utils/pkg/api/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TestJobDeadline tests that a task that takes 30 seconds to complete
+// (sleeping) succeeds or fails with different settings of taskDeadlineSeconds
+func TestJobDeadline(t *testing.T) {
+	if !isE2ETestingAllowed() {
+		t.Skipf("Skipping %s, not allowed by environment", t.Name())
+	}
+
+	testEnv, err := newTestEnvironment(
+		"../events/e2e/taskdeadline.triggered.json",
+		"../shipyard/e2e/taskdeadline.deployment.yaml",
+		"../data/e2e/taskdeadline.config.yaml",
+	)
+
+	err = testEnv.SetupTestEnvironment()
+	require.NoError(t, err)
+
+	// Make sure project is delete after the tests are completed
+	defer testEnv.Cleanup()
+
+	tests := []struct {
+		name               string
+		taskDeadline       string
+		expectedCloudEvent eventData
+	}{
+		{
+			name:         "No deadline set - job completes successfully",
+			taskDeadline: "0",
+			expectedCloudEvent: eventData{
+				Project: testEnv.EventData.Project,
+				Result:  "pass",
+				Service: testEnv.EventData.Service,
+				Stage:   testEnv.EventData.Stage,
+				Status:  "succeeded",
+			},
+		},
+		{
+			name:         "Deadline too short - job fails",
+			taskDeadline: "10",
+			expectedCloudEvent: eventData{
+				Project: testEnv.EventData.Project,
+				Result:  "fail",
+				Service: testEnv.EventData.Service,
+				Stage:   testEnv.EventData.Stage,
+				Status:  "errored",
+			},
+		},
+		{
+			name:         "Deadline long enough - job succeeds",
+			taskDeadline: "60",
+			expectedCloudEvent: eventData{
+				Project: testEnv.EventData.Project,
+				Result:  "pass",
+				Service: testEnv.EventData.Service,
+				Stage:   testEnv.EventData.Stage,
+				Status:  "succeeded",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(
+			test.name, func(t *testing.T) {
+				initialTaskDeadline, err := setConfigMap(
+					testEnv.K8s, testEnv.Namespace, "job-service-config", "task_deadline_seconds",
+					test.taskDeadline,
+				)
+
+				require.NoError(t, err)
+
+				defer func() {
+					setConfigMap(
+						testEnv.K8s, testEnv.Namespace, "job-service-config", "task_deadline_seconds",
+						initialTaskDeadline,
+					)
+					restartJESPod(testEnv.K8s, testEnv.Namespace)
+				}()
+
+				err = restartJESPod(testEnv.K8s, testEnv.Namespace)
+
+				require.NoError(t, err)
+
+				// Send the event to keptn
+				keptnContext, err := testEnv.API.SendEvent(testEnv.Event)
+				require.NoError(t, err)
+
+				// Checking if the job executor service responded with a .started event
+				requireWaitForEvent(
+					t,
+					testEnv.API,
+					2*time.Minute,
+					1*time.Second,
+					keptnContext,
+					"sh.keptn.event.deployment.started",
+					func(_ *models.KeptnContextExtendedCE) bool {
+						return true
+					},
+				)
+
+				requireWaitForEvent(
+					t,
+					testEnv.API,
+					2*time.Minute,
+					1*time.Second,
+					keptnContext,
+					"sh.keptn.event.deployment.finished",
+					func(event *models.KeptnContextExtendedCE) bool {
+						responseEventData, err := parseKeptnEventData(event)
+						require.NoError(t, err)
+
+						t.Log(responseEventData.Message)
+
+						responseEventData.Message = ""
+
+						assert.Equal(t, test.expectedCloudEvent, *responseEventData)
+						return true
+					},
+				)
+			},
+		)
+	}
+
+}
+
+func restartJESPod(clientset *kubernetes.Clientset, namespace string) error {
+	selector := labels.NewSelector()
+	nameSelector, _ := labels.NewRequirement(
+		"app.kubernetes.io/name", selection.Equals, []string{"job-executor-service"},
+	)
+	selector = selector.Add(*nameSelector)
+	pods, err := clientset.CoreV1().Pods(namespace).List(
+		context.Background(), metav1.ListOptions{LabelSelector: selector.String()},
+	)
+
+	if err != nil {
+		return fmt.Errorf("unable to list JES pods in namespace %s: %w", namespace, err)
+	}
+
+	for _, pod := range pods.Items {
+		clientset.CoreV1().Pods(namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+	}
+	return nil
+}
+
+func setConfigMap(
+	clientset *kubernetes.Clientset, namespace string, configMapName string, key string, value string,
+) (string,
+	error) {
+
+	configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(
+		context.Background(), configMapName, metav1.GetOptions{},
+	)
+
+	if err != nil {
+		return "", fmt.Errorf("failed getting configmap %s in namespace %s: %w", configMap, namespace, err)
+	}
+
+	prevValue := configMap.Data[key]
+	configMap.Data[key] = value
+
+	_, err = clientset.CoreV1().ConfigMaps(namespace).Update(
+		context.Background(), configMap, metav1.UpdateOptions{},
+	)
+
+	return prevValue, err
+}

--- a/test/events/e2e/taskdeadline.triggered.json
+++ b/test/events/e2e/taskdeadline.triggered.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "project": "e2e-project",
+    "service": "e2e-service",
+    "stage": "e2e",
+    "labels": {
+      "sleep": "30"
+    }
+  },
+  "source": "e2e-test",
+  "specversion": "1.0",
+  "type": "sh.keptn.event.e2e.jes.triggered"
+}

--- a/test/shipyard/e2e/taskdeadline.deployment.yaml
+++ b/test/shipyard/e2e/taskdeadline.deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: "spec.keptn.sh/0.2.2"
+kind: "Shipyard"
+metadata:
+  name: "e2e-deployment-shipyard"
+spec:
+  stages:
+    - name: "e2e"
+      sequences:
+        - name: "jes"
+          tasks:
+            - name: "deployment"


### PR DESCRIPTION
Added a new setting in the helm chart `jobconfig.taskDeadlineSeconds`: if set to a value > 0 jobs exceeding the deadline will be  terminated.

The feature is disabled by default.