### PR TITLE
test: remove bash tracing in wait for k3s readiness in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -59,7 +59,8 @@ jobs:
       - name: Wait for K3s to become ready
         timeout-minutes: 1
         run: |
-          set -x
+          # uncomment the line below for debugging
+          # set -x
           k3sReady=$(kubectl get node $(hostname) -ogo-template --template="{{ range .status.conditions }} {{- if eq .type \"Ready\" }}{{ .status }} {{- end }} {{- end }}" || echo "")
           while [ "$k3sReady" != "True" ]; do
           echo "K3s is not ready yet, sleep awhile to let things settle"


### PR DESCRIPTION
Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>