### PR TITLE
chore: set helm chart version to 0.0.0-dev

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.1.4
+appVersion: 0.0.0-dev
 description: Helm Chart for the keptn job-executor-service
 name: job-executor-service
 type: application
-version: 0.1.4
+version: 0.0.0-dev


### PR DESCRIPTION
Set helm chart version to 0.0.0-dev (was 0.1.4 before).

This helps when deploying the chart using skaffold.

Note: The actual version is set as part of the build-helm-chart workflow:

![image](https://user-images.githubusercontent.com/56065213/168569241-7aeaca2d-b9b2-4ad1-ab29-55ed3f9b6f9f.png)
