### PR TITLE
fix: Add output of failed events to logs

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -38,6 +38,13 @@ rules:
       - "get"
       - "create"
       - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "list"
+      - "get"
 ---
 # Bind role for accessing secrets onto the job-executor-service service account
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/eventhandler/fake/eventhandlers_mock.go
+++ b/pkg/eventhandler/fake/eventhandlers_mock.go
@@ -194,6 +194,21 @@ func (mr *MockK8sMockRecorder) CreateK8sJob(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateK8sJob", reflect.TypeOf((*MockK8s)(nil).CreateK8sJob), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// GetFailedEventsForJob mocks base method.
+func (m *MockK8s) GetFailedEventsForJob(arg0, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFailedEventsForJob", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFailedEventsForJob indicates an expected call of GetFailedEventsForJob.
+func (mr *MockK8sMockRecorder) GetFailedEventsForJob(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailedEventsForJob", reflect.TypeOf((*MockK8s)(nil).GetFailedEventsForJob), arg0, arg1)
+}
+
 // GetLogsOfPod mocks base method.
 func (m *MockK8s) GetLogsOfPod(arg0, arg1 string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Disclaimer: Thanks to the code provided by @Raffy23 in PR https://github.com/keptn-contrib/job-executor-service/pull/229

Fixes #234 by providing an appropriate error message

![image](https://user-images.githubusercontent.com/56065213/168596118-6f692a9a-5b04-4310-972c-19c80da9588d.png)


Unfortunately, we cannot easily fix #235, as it would require us to delete jobs (which we shouldn't do at the moment). I would dedicate the fix of #235 to the refactoring ticket of #244

