### PR TITLE
feat: Replace polling for jobs with watch

### DIFF
--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -45,6 +45,7 @@ rules:
     verbs:
       - "list"
       - "get"
+      - "watch"
 ---
 # Bind role for accessing secrets onto the job-executor-service service account
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -53,9 +53,7 @@ type K8s interface {
 		jobName string, jobDetails k8sutils.JobDetails, eventData keptn.EventProperties,
 		jobSettings k8sutils.JobSettings, jsonEventData interface{}, namespace string,
 	) error
-	AwaitK8sJobDone(
-		jobName string, maxPollDuration time.Duration, pollIntervalInSeconds time.Duration, namespace string,
-	) error
+	AwaitK8sJobDone(jobName string, maxPollDuration time.Duration, namespace string) error
 	GetFailedEventsForJob(jobName string, namespace string) (string, error)
 	GetLogsOfPod(jobName string, namespace string) (string, error)
 }
@@ -217,7 +215,7 @@ func (eh *EventHandler) startK8sJob(action *config.Action, actionIndex int, conf
 		if task.MaxPollDuration != nil {
 			maxPollDuration = time.Duration(*task.MaxPollDuration) * time.Second
 		}
-		jobErr := eh.K8s.AwaitK8sJobDone(jobName, maxPollDuration, pollInterval, namespace)
+		jobErr := eh.K8s.AwaitK8sJobDone(jobName, maxPollDuration, namespace)
 
 		logs, err := eh.K8s.GetLogsOfPod(jobName, namespace)
 		if err != nil {

--- a/pkg/eventhandler/eventhandlers_test.go
+++ b/pkg/eventhandler/eventhandlers_test.go
@@ -418,7 +418,7 @@ func TestEventMatching(t *testing.T) {
 				// CreateK8sJob expectation above, to avoid too much complexity we just expect anything for the correct
 				// number of times
 				mockK8s.EXPECT().AwaitK8sJobDone(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Times(totalNoOfExpectedTasks)
 
 				mockK8s.EXPECT().GetLogsOfPod(
@@ -505,8 +505,8 @@ func TestStartK8s(t *testing.T) {
 		}), gomock.Any(), gomock.Any(),
 		gomock.Any(), jobNamespace2,
 	).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), 1006*time.Second, pollInterval, jobNamespace1).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName2), defaultMaxPollDuration, pollInterval, jobNamespace2).Times(1)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), 1006*time.Second, jobNamespace1).Times(1)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName2), defaultMaxPollDuration, jobNamespace2).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1), jobNamespace1).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName2), jobNamespace2).Times(1)
 
@@ -557,7 +557,7 @@ func TestStartK8sJobSilent(t *testing.T) {
 	k8sMock.EXPECT().CreateK8sJob(
 		gomock.Eq(jobName2), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Any(), defaultMaxPollDuration, pollInterval, "").Times(2)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Any(), defaultMaxPollDuration, "").Times(2)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1), gomock.Any()).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName2), gomock.Any()).Times(1)
 
@@ -597,7 +597,7 @@ func TestStartK8s_TestFinishedEvent(t *testing.T) {
 	k8sMock.EXPECT().CreateK8sJob(
 		gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), gomock.Any(), gomock.Any()).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1), gomock.Any()).Times(1)
 
 	// set the global timezone for testing
@@ -669,7 +669,7 @@ func TestExpectImageNotAllowedError(t *testing.T) {
 	k8sMock.EXPECT().CreateK8sJob(
 		gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Times(1)
-	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	k8sMock.EXPECT().AwaitK8sJobDone(gomock.Eq(jobName1), gomock.Any(), gomock.Any()).Times(1)
 	k8sMock.EXPECT().GetLogsOfPod(gomock.Eq(jobName1), gomock.Any()).Times(1)
 
 	// set the global timezone for testing

--- a/pkg/eventhandler/fake/eventhandlers_mock.go
+++ b/pkg/eventhandler/fake/eventhandlers_mock.go
@@ -153,17 +153,17 @@ func (m *MockK8s) EXPECT() *MockK8sMockRecorder {
 }
 
 // AwaitK8sJobDone mocks base method.
-func (m *MockK8s) AwaitK8sJobDone(arg0 string, arg1, arg2 time.Duration, arg3 string) error {
+func (m *MockK8s) AwaitK8sJobDone(arg0 string, arg1 time.Duration, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AwaitK8sJobDone", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AwaitK8sJobDone", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AwaitK8sJobDone indicates an expected call of AwaitK8sJobDone.
-func (mr *MockK8sMockRecorder) AwaitK8sJobDone(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockK8sMockRecorder) AwaitK8sJobDone(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitK8sJobDone", reflect.TypeOf((*MockK8s)(nil).AwaitK8sJobDone), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitK8sJobDone", reflect.TypeOf((*MockK8s)(nil).AwaitK8sJobDone), arg0, arg1, arg2)
 }
 
 // ConnectToCluster mocks base method.


### PR DESCRIPTION
## This PR
- replaces the polling loop in `AwaitK8sJobDone` with a watch that is able to listen to changes to the job
- introduces a watch for events in `AwaitK8sJobDone` to catch errors while creating a Pod (unsound spec, image pull errors)

## Related
- #244
- #254