### PR TITLE
feat: Keptn 0.17 compatibility

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.15.1", "0.16.1", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.16.1", "0.17.0", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
         network-policy: [true, false]
         job-network-policy: [true, false]
     env:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ running in the Keptn ecosystem:
 |    0.15.x     |                               keptncontrib/job-executor-service:0.2.2                                |       v2       |
 |    0.16.x     |                               keptncontrib/job-executor-service:0.2.3                                |       v2       |
 |    0.16.x     |                               keptncontrib/job-executor-service:0.2.4                                |       v2       |
+|    0.17.x     |                               keptncontrib/job-executor-service:0.2.5                                |       v2       |
+
 
 **Please Note**:
 - Newer Keptn versions might be compatible, but compatibility has not been verified at the time of the release.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -193,6 +193,8 @@ spec:
                     name: job-service-config
                     key: oauth_scopes
             {{- end }}
+            - name: API_PROXY_MAX_PAYLOAD_BYTES_KB
+              value: "128"
       volumes:
         - name: job-executor-settings
           projected:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,7 +18,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.16.1"                             # Container Tag
+    tag: "0.17.0"                             # Container Tag
   config:
     queueGroup:
       enabled: true                          # Enable connection via Nats queue group to support exactly-once message processing


### PR DESCRIPTION
* Upgrade keptn/distributor to 0.17.0
* Set `API_PROXY_MAX_PAYLOAD_BYTES_KB` to 64 (kilobytes) to allow large logs to be transmitted via distributor
* Update integration test matrix

Integration Test: https://github.com/keptn-contrib/job-executor-service/actions/runs/2826043359
