### PR TITLE
feat: Add Keptn dev version to integration tests

### DIFF
--- a/.github/actions/github-script/fetch_keptn_versions.sh
+++ b/.github/actions/github-script/fetch_keptn_versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Fetch latest release and prerelease
+prerelease=$(curl -s https://api.github.com/repos/keptn/keptn/releases | jq -r 'map(select(.prerelease)) | first | .tag_name')
+release=$(curl -s https://api.github.com/repos/keptn/keptn/releases | jq -r 'map(select(.prerelease==false)) | first | .tag_name')
+
+matrix_config=""
+
+# Write variables as output
+echo "::set-output name=LATEST_RELEASE::$release"
+echo "::set-output name=LATEST_PRERELEASE::$prerelease"

--- a/.github/actions/github-script/fetch_keptn_versions.sh
+++ b/.github/actions/github-script/fetch_keptn_versions.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 # Fetch latest release and prerelease
-prerelease=$(curl -s https://api.github.com/repos/keptn/keptn/releases | jq -r 'map(select(.prerelease)) | first | .tag_name')
-release=$(curl -s https://api.github.com/repos/keptn/keptn/releases | jq -r 'map(select(.prerelease==false)) | first | .tag_name')
-
-matrix_config=""
+prerelease=$(curl -s https://api.github.com/repos/keptn/keptn/releases | jq -r 'map(select(.prerelease)) | sort_by(.tag_name)[-1].tag_name')
+release=$(curl --silent "https://api.github.com/repos/keptn/keptn/releases/latest" | jq -r '.tag_name')
 
 # Write variables as output
 echo "::set-output name=LATEST_RELEASE::$release"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,13 +11,28 @@ defaults:
     shell: bash
 
 jobs:
+  prepare:
+    name: Prepare integration test run
+    runs-on: ubuntu-20.04
+    outputs:
+      LATEST_KEPTN_RELEASE: ${{ steps.prepare_keptn_version_matrix.outputs.LATEST_RELEASE }}
+      LATEST_KEPTN_PRERELEASE: ${{ steps.prepare_keptn_version_matrix.outputs.LATEST_PRERELEASE }}
+    steps:
+      - name: Check out code.
+        uses: actions/checkout@v3.0.2
+
+      - name: Prepare Keptn version matrix
+        id: prepare_keptn_version_matrix
+        run: |
+          ./.github/actions/github-script/fetch_keptn_versions.sh
   integration_test:
     name: "Integration Tests"
+    needs: prepare
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.13.5", "0.14.2", "0.15.1", "0.16.0"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.13.5", "0.14.2", "0.15.1", "0.16.0", "${{ needs.prepare.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.prepare.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
         network-policy: [true, false]
         job-network-policy: [true, false]
     env:
@@ -116,9 +131,27 @@ jobs:
             --set gitea.admin.password=${GITEA_ADMIN_PASSWORD} \
             --wait
 
+      - name: Check Helm repo for image
+        id: helm_repo_check
+        shell: bash
+        env:
+          KEPTN_VERSION: ${{ matrix.keptn-version }}
+        run: |
+          echo "Keptn Version: $KEPTN_VERSION"
+          helm repo add keptn https://charts.keptn.sh
+          helm_search=$(helm search repo keptn/keptn --version $KEPTN_VERSION)
+          
+          if [[ "$helm_search" != "No results found" ]]; then
+          echo "Using standard Helm repo"
+          echo "::set-output name=HELM_REPO::https://charts.keptn.sh"
+          else
+          echo "Using dev Helm repo"
+          echo "::set-output name=HELM_REPO::https://charts-dev.keptn.sh"
+          fi
+
       - name: Install Keptn
         id: install_keptn
-        uses: keptn-sandbox/action-install-keptn@v2.0.0
+        uses: keptn-sandbox/action-install-keptn@main
         timeout-minutes: 5
         with:
           KEPTN_VERSION: ${{ matrix.keptn-version }}
@@ -129,6 +162,7 @@ jobs:
               features:
                 automaticProvisioningURL: http://keptn-gitea-provisioner-service.default
           KUBECONFIG: ${{ env.KUBECONFIG }}
+          KEPTN_HELM_CHART_REPO: ${{ steps.helm_repo_check.outputs.HELM_REPO }}
 
       - name: Test connection to keptn
         run: |
@@ -255,14 +289,14 @@ jobs:
 
             fileList.forEach(fileName => {
               console.log(`Reading file: ${fileName}`);
-              
+            
               const platformReportFile = fs.readFileSync(TEST_REPORTS_PATH + fileName, {encoding:'utf8', flag:'r'});
-              
+            
               const keptnVersion = keptnVersionRegex.exec(fileName)[1];
               const testResults = ndJsonParser(platformReportFile);
-              
+            
               keptnVersionCount++;
-              
+            
               testResults.forEach(testResult => {
 
                 if (testResult.Test !== undefined && (testResult.Action === "pass" || testResult.Action === "fail" || testResult.Action ===  "skip")) {
@@ -339,7 +373,7 @@ jobs:
           fi
 
           INTEGRATION_FILE_LINK=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/$BRANCH/.github/workflows/integration_tests.yaml
-            
+          
           # Create issue for the failed integration test:  
           cat <<EOT >> integration-tests-failed.md
           ---

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -139,9 +139,9 @@ jobs:
         run: |
           echo "Keptn Version: $KEPTN_VERSION"
           helm repo add keptn https://charts.keptn.sh
-          helm_search=$(helm search repo keptn/keptn --version $KEPTN_VERSION)
+          helm_search=$(helm search repo keptn/keptn --version $KEPTN_VERSION -o json | jq '. | length')
           
-          if [[ "$helm_search" != "No results found" ]]; then
+          if [[ "$helm_search" != "0" ]]; then
           echo "Using standard Helm repo"
           echo "::set-output name=HELM_REPO::https://charts.keptn.sh"
           else

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 jobs:
-  prepare:
-    name: Prepare integration test run
+  fetch_latest_keptn_versions:
+    name: Fetch latest Keptn version for integration test run
     runs-on: ubuntu-20.04
     outputs:
       LATEST_KEPTN_RELEASE: ${{ steps.prepare_keptn_version_matrix.outputs.LATEST_RELEASE }}
@@ -27,12 +27,12 @@ jobs:
           ./.github/actions/github-script/fetch_keptn_versions.sh
   integration_test:
     name: "Integration Tests"
-    needs: prepare
+    needs: fetch_latest_keptn_versions
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.13.5", "0.14.2", "0.15.1", "0.16.0", "${{ needs.prepare.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.prepare.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.13.5", "0.14.2", "0.15.1", "0.16.0", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
         network-policy: [true, false]
         job-network-policy: [true, false]
     env:
@@ -151,7 +151,7 @@ jobs:
 
       - name: Install Keptn
         id: install_keptn
-        uses: keptn-sandbox/action-install-keptn@main
+        uses: keptn-sandbox/action-install-keptn@v3.0.0
         timeout-minutes: 5
         with:
           KEPTN_VERSION: ${{ matrix.keptn-version }}


### PR DESCRIPTION
## This PR

- Fetches the latest Keptn release and prerelease
- Adds the versions to the Github action matrix
- Checks if the Keptn chart is available in the default Helm repository (`https://charts.keptn.sh`). If not, `https://charts-dev.keptn.sh` is used instead.

Integration Tests: https://github.com/keptn-contrib/job-executor-service/actions/runs/2649231941