### PR TITLE
chore: Improve integration tests log output

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -186,8 +186,11 @@ jobs:
           kubectl get all -n keptn -o json > k8s_debug/k8s_keptn_objects.json
           kubectl get configmaps,deployments,pods,networkpolicy,serviceaccounts,role,rolebindings,events -n ${JES_NAMESPACE} -o json > k8s_debug/k8s_jes_objects.json
           kubectl logs -n keptn -l app.kubernetes.io/instance=keptn --prefix=true --previous=false --all-containers --tail=-1 > k8s_debug/k8s_keptn_logs.txt || true
+          kubectl logs -n keptn -l app.kubernetes.io/instance=keptn --prefix=true --previous=true --all-containers --tail=-1 > k8s_debug/k8s_keptn_prev_logs.txt || true
           kubectl logs -n ${JES_NAMESPACE} deployment/job-executor-service --prefix=true --previous=false --all-containers --tail=-1 > k8s_debug/k8s_jes_logs.txt || true
+          kubectl logs -n ${JES_NAMESPACE} deployment/job-executor-service --prefix=true --previous=true --all-containers --tail=-1 > k8s_debug/k8s_jes_prev_logs.txt || true
           kubectl logs deployment/keptn-gitea-provisioner-service --prefix=true --previous=false --all-containers --tail=-1 > k8s_debug/k8s_gitea_provisioner_logs.txt || true
+          kubectl logs deployment/keptn-gitea-provisioner-service --prefix=true --previous=true --all-containers --tail=-1 > k8s_debug/k8s_gitea_provisioner_prev_logs.txt || true
           kubectl get statefulsets,configmaps,pods,networkpolicy,serviceaccounts,role,rolebindings,events,services -n ${GITEA_NAMESPACE} -o json > k8s_debug/k8s_objects_gitea.json
           kubectl logs statefulsets/gitea --prefix=true --previous=false --all-containers -n ${GITEA_NAMESPACE} --tail=-1 > k8s_debug/k8s_logs_gitea.txt || true
 


### PR DESCRIPTION
## This PR
- includes previous containers in logs to make it easier to debug if a service crashes 