### PR TITLE
chore: Update pipeline to be compatible with Keptn 0.17

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.13.5", "0.14.2", "0.15.1", "0.16.0", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.15.1", "0.16.1", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_RELEASE }}", "${{ needs.fetch_latest_keptn_versions.outputs.LATEST_KEPTN_PRERELEASE }}"] # https://github.com/keptn/keptn/releases
         network-policy: [true, false]
         job-network-policy: [true, false]
     env:
@@ -156,6 +156,13 @@ jobs:
         with:
           KEPTN_VERSION: ${{ matrix.keptn-version }}
           HELM_VALUES: |
+            # Keptn 0.17 and newer
+            apiGatewayNginx:
+              type: LoadBalancer
+            features:
+              automaticProvisioning:
+                serviceURL: http://keptn-gitea-provisioner-service.default
+            # Keptn 0.16 compatibility
             control-plane:
               apiGatewayNginx:
                 type: LoadBalancer


### PR DESCRIPTION
With PR #314 we are now testing against newer Keptn version (latest release and latest pre-release). However, it seems that we're not compatible.
![image](https://user-images.githubusercontent.com/56065213/179933648-988a5f70-7bb8-4436-926d-3fcb12aa92f5.png)


This PR updates pipeline code to be compatible with Keptn 0.17 (note: this only proves that we're compatible with Keptn 0.17, we haven't put any effort into making it compatible, e.g., using a new distributor version).

I also slimmed down and updated the test matrix for Keptn versions, e.g.:
* Removed 0.13.x (we have plenty of 0.13 compatible releases that people can use)
* Removed 0.14.x (we have plenty of 0.14 compatible releases that people can use)
* Keep 0.15.1
* Update from 0.16.0 to 0.16.1

Integration Test Run: https://github.com/keptn-contrib/job-executor-service/actions/runs/2703312389

